### PR TITLE
Add ISOcountryCode to the list of properties parsed from CLPlacemark

### DIFF
--- a/Pod/Classes/SwiftLocation.swift
+++ b/Pod/Classes/SwiftLocation.swift
@@ -1073,6 +1073,7 @@ private class SwiftLocationParser: NSObject {
 		self.subLocality = placemark.subLocality ?? ""
 		self.administrativeArea = placemark.administrativeArea ?? ""
 		self.country = placemark.country ?? ""
+        self.ISOcountryCode = placemark.ISOcountryCode ?? ""
         if let location = placemark.location {
             self.longitude = location.coordinate.longitude.description;
             self.latitude = location.coordinate.latitude.description

--- a/Pod/Classes/SwiftLocation.swift
+++ b/Pod/Classes/SwiftLocation.swift
@@ -1073,7 +1073,7 @@ private class SwiftLocationParser: NSObject {
 		self.subLocality = placemark.subLocality ?? ""
 		self.administrativeArea = placemark.administrativeArea ?? ""
 		self.country = placemark.country ?? ""
-        self.ISOcountryCode = placemark.ISOcountryCode ?? ""
+		self.ISOcountryCode = placemark.ISOcountryCode ?? ""
         if let location = placemark.location {
             self.longitude = location.coordinate.longitude.description;
             self.latitude = location.coordinate.latitude.description


### PR DESCRIPTION
The CLPlacemark's ISOcountryCode property was being ignored. I've added it to the parsing code. 
NOTE: This is my first OSS pull request so please let me know if I've done anything wrong.
