### PR TITLE
Various fixes on location timeout 

### DIFF
--- a/src/DataTypes.swift
+++ b/src/DataTypes.swift
@@ -32,7 +32,7 @@ import MapKit
 
 /// Handlers
 
-public typealias LocationHandlerError = (LocationError -> Void)
+public typealias LocationHandlerError = ((CLLocation?, LocationError) -> Void)
 public typealias LocationHandlerSuccess = (CLLocation -> Void)
 public typealias LocationHandlerPaused = (CLLocation? -> Void)
 

--- a/src/LocationManager.swift
+++ b/src/LocationManager.swift
@@ -390,7 +390,9 @@ public class LocationManager: NSObject, CLLocationManagerDelegate {
 	
 	private func pauseAllLocationRequest() {
 		self.locationObservers.forEach { handler in
-			handler.pause()
+            if handler.isEnabled {
+                handler.pause()
+            }
 		}
 	}
 	

--- a/src/LocationManager.swift
+++ b/src/LocationManager.swift
@@ -32,7 +32,7 @@ import MapKit
 
 public class LocationManager: NSObject, CLLocationManagerDelegate {
 	//MARK: Public Variables
-	private(set) var lastLocation: CLLocation?
+	public private(set) var lastLocation: CLLocation?
 
 		/// Shared instance of the location manager
 	public static let shared = LocationManager()

--- a/src/LocationRequest.swift
+++ b/src/LocationRequest.swift
@@ -159,13 +159,12 @@ public class LocationRequest: LocationManagerRequest {
 	
 	//MARK: - Private Methods
 	
-	internal func setTimeoutTimer(start: Bool) {
-		if let _ = self.timeoutTimer {
-			self.timeoutTimer!.invalidate()
-			self.timeoutTimer = nil
-		}
-		guard start == true, let interval = self.timeout else { return }
-		self.timeoutTimer = NSTimer(timeInterval: interval, target: self, selector: #selector(timeoutTimerFired), userInfo: nil, repeats: false)
+	internal func setTimeoutTimer(shouldStart: Bool) {
+        self.timeoutTimer?.invalidate()
+        self.timeoutTimer = nil
+        
+		guard let interval = self.timeout where shouldStart else { return }
+		self.timeoutTimer = NSTimer.scheduledTimerWithTimeInterval(interval, target: self, selector: #selector(timeoutTimerFired), userInfo: nil, repeats: false)
 	}
 	
 	@objc func timeoutTimerFired() {

--- a/src/LocationRequest.swift
+++ b/src/LocationRequest.swift
@@ -64,8 +64,8 @@ public class LocationRequest: LocationManagerRequest {
 		/// A nil value means "do not use timeout".
 	public var timeout: NSTimeInterval? = nil
 	
-		/// This is the last location received for this request. Maybe nil if any valid request is received yet.
-	private(set) var lastLocation: CLLocation?
+		/// This is the last location matching the requested accuracy received for this request. Maybe nil if any valid request is received yet.
+	private(set) var lastValidLocation: CLLocation?
 	
 		/// This is the frequency internval you want to receive updates about this monitor session
 	public var frequency: UpdateFrequency = .Continuous {
@@ -186,8 +186,8 @@ public class LocationRequest: LocationManagerRequest {
 			if self.isValidLocation(location) == false {
 				return false
 			}
-			self.lastLocation = location
-			self.onSuccessHandler?(self.lastLocation!)
+			self.lastValidLocation = location
+			self.onSuccessHandler?(self.lastValidLocation!)
 			if self.frequency == .OneShot {
 				self.stop()
 			}
@@ -203,17 +203,17 @@ public class LocationRequest: LocationManagerRequest {
 			return false
 		}
 		
-		if let lastLocation = self.lastLocation {
+		if let lastValidLocation = self.lastValidLocation {
 			if case .ByDistanceIntervals(let meters) = self.frequency {
-				let distanceSinceLastReport = lastLocation.distanceFromLocation(loc)
+				let distanceSinceLastReport = lastValidLocation.distanceFromLocation(loc)
 				if distanceSinceLastReport < meters {
 					return false
 				}
 			}
 		}
 		
-		let afterLastLocation = (self.lastLocation == nil ? true : loc.timestamp.timeIntervalSince1970 >= self.lastLocation!.timestamp.timeIntervalSince1970)
-		if afterLastLocation == false {
+		let afterLastValidLocation = (self.lastValidLocation == nil ? true : loc.timestamp.timeIntervalSince1970 >= self.lastValidLocation!.timestamp.timeIntervalSince1970)
+		if afterLastValidLocation == false {
 			return false
 		}
 		
@@ -221,7 +221,7 @@ public class LocationRequest: LocationManagerRequest {
 	}
 	
 	public func reverseLocation(onSuccess sHandler: RLocationSuccessHandler, onError fHandler: RLocationErrorHandler) throws  {
-		guard let loc = self.lastLocation else {
+		guard let loc = self.lastValidLocation else {
 			throw LocationError.LocationNotAvailable
 		}
 		LocationManager.shared.reverseLocation(location: loc, onSuccess: sHandler, onError: fHandler)


### PR DESCRIPTION
These commit fix a couple of issues with timeout.
1. timeout wasn't firing because the NSTimer wasn't added to the run loop. Instead I replaced the init with `scheduledTimerWithTimeInterval`
2. People are complaining that some accuracy locations do not work. This is actually not the case, instead the accuracy simply can't be reached (for ex. because I'm inside a building with lower precision on GPS). I implemented some changes in order to return the best effort location along with the timeout error. This way you can at least receive one location while eventually retrying again to request location:

```
        highPrecisionLocationManager = LocationManager.shared.observeLocations(.House, frequency: .OneShot, onSuccess: { location in
            print(location)
        }) { (bestEffortLocation, error) in
            switch error {
            case .RequestTimeout:
                print(bestEffortLocation)
            default:
                break
            }
        }
        highPrecisionLocationManager.timeout = 5.0
```
