### PR TITLE
fixed issue, previnting heading updates from being delivered

### DIFF
--- a/src/LocationManager.swift
+++ b/src/LocationManager.swift
@@ -358,6 +358,7 @@ public class LocationManager: NSObject, CLLocationManagerDelegate {
 				self.headingObservers.append(request)
 			}
 			self.updateHeadingService()
+            return true
 		}
 		else if let request = request as? LocationRequest {
 			if self.locationObservers.indexOf({$0.UUID == request.UUID}) == nil {


### PR DESCRIPTION
looks like missing `return true` statement, resulted in heading updates being enabled and disabled immediately.
