### PR TITLE
Make lastLocation Public, BackgroundUpdates optional for significantUpdates

### DIFF
--- a/Sources/SwiftLocation/Frequency.swift
+++ b/Sources/SwiftLocation/Frequency.swift
@@ -63,7 +63,7 @@ public enum Frequency: Equatable, Comparable, CustomStringConvertible {
 	case continuous
 	case oneShot
 	case deferredUntil(distance: Double, timeout: TimeInterval, navigation: Bool)
-	case significant
+  case significant(allowsBackgroundUpdates: Bool)
 	
 	public var description: String {
 		switch self {
@@ -73,8 +73,8 @@ public enum Frequency: Equatable, Comparable, CustomStringConvertible {
 			return "One Shot"
 		case .deferredUntil(let m, let t, let n):
 			return "Deferred until (\(m) meters or \(t) seconds " + (n == true ? "navigation" : "best") + ")"
-		case .significant:
-			return "Significant"
+		case .significant(let allowsBackgroundUpdates):
+      return "Significant with background updates: \(allowsBackgroundUpdates == true ? "true" : "false")"
 		}
 	}
 	
@@ -105,8 +105,8 @@ public func <(lhs: Frequency, rhs: Frequency) -> Bool {
 		return true
 	case (.deferredUntil(let d1,_,_), .deferredUntil(let d2,_,_)):
 		return d1 < d2
-	case (.significant, .significant):
-		return true
+	case (.significant(let backgroundUpdates1), .significant):
+		return backgroundUpdates1
 	default:
 		return false
 	}

--- a/Sources/SwiftLocation/LocationTracker.swift
+++ b/Sources/SwiftLocation/LocationTracker.swift
@@ -148,14 +148,14 @@ public final class LocationTracker: NSObject, CLLocationManagerDelegate {
 			self.onChangeTrackerSettings?(settings)
 
 			switch settings.frequency {
-			case .significant:
+			case .significant(let allowsBackgroundUpdates):
 				guard CLLocationManager.significantLocationChangeMonitoringAvailable() else {
 					locationManager.stopAllLocationServices()
 					return
 				}
 				// If best frequency is significant location update (and hardware supports it) then start only significant location update
 				locationManager.stopUpdatingLocation()
-				locationManager.allowsBackgroundLocationUpdates = true
+				locationManager.allowsBackgroundLocationUpdates = allowsBackgroundUpdates
 				locationManager.startMonitoringSignificantLocationChanges()
 			case .deferredUntil(_,_,_):
 				locationManager.stopMonitoringSignificantLocationChanges()
@@ -678,7 +678,7 @@ public final class LocationTracker: NSObject, CLLocationManagerDelegate {
 		}
 		
 		var accuracy: Accuracy = .any
-		var frequency: Frequency = .significant
+    var frequency: Frequency = .significant(allowsBackgroundUpdates: false)
 		var type: CLActivityType = .other
 		var distanceFilter: CLLocationDistance? = kCLDistanceFilterNone
 		

--- a/Sources/SwiftLocation/Structs.swift
+++ b/Sources/SwiftLocation/Structs.swift
@@ -74,9 +74,9 @@ public struct TrackerSettings: CustomStringConvertible, Equatable {
 
 public struct LastLocation {
 	/// This is the best accurated measured location (may be old, check the `timestamp`)
-	private(set) var bestAccurated: CLLocation?
+	public private(set) var bestAccurated: CLLocation?
 	/// This represent the last measured location by timestamp (may be innacurate, check `accuracy`)
-	private(set) var last: CLLocation?
+	public private(set) var last: CLLocation?
 	
 	/// Store last value
 	///


### PR DESCRIPTION
Not sure if this is desired in master, but I ran into an issue where .significant for frequency forces the app to use the location UIBackgroundMode. This is actually an optional requirement to take advantage of Significant Location Changes, and my application has previously been rejected because I don't need to enable the UIBackgroundMode.