### PR TITLE
Use HTTPS for FreeGeoIP

### DIFF
--- a/Sources/Shared.swift
+++ b/Sources/Shared.swift
@@ -44,7 +44,7 @@ public enum IPService {
 	internal var url: URL {
 		var url: String = ""
 		switch self {
-		case .freeGeoIP:	url = "http://freegeoip.net/json/"
+		case .freeGeoIP:	url = "https://freegeoip.net/json/"
 		case .petabyet:		url = "http://api.petabyet.com/geoip/"
 		case .smartIP:		url = "http://smart-ip.net/geoip-json/"
 		case .ipApi:		url = "http://ip-api.com/json"


### PR DESCRIPTION
Use HTTPS for FreeGeoIP, it's more secure, and avoids having to use an ATS exception.