### PR TITLE
Support only using WhenInUse on iOS 11

### DIFF
--- a/Sources/Shared.swift
+++ b/Sources/Shared.swift
@@ -244,12 +244,15 @@ public extension CLLocationManager {
 		} else {
 			// In iOS11 stuff are changed again
 			let hasAlwaysAndInUseKey = hasPlistValue(forKey: "NSLocationAlwaysAndWhenInUseUsageDescription")
+            let hasWhenInUse = hasPlistValue(forKey: "NSLocationWhenInUseUsageDescription")
 			if hasAlwaysAndInUseKey {
 				return .always
-			} else {
-				// Key NSLocationAlwaysAndWhenInUseUsageDescription MUST be present in the Info.plist
-				// file to use location services on iOS 11+.
-				fatalError("To use location services in iOS 11+, your Info.plist must provide a value for NSLocationAlwaysAndWhenInUseUsageDescription.")
+            } else if hasWhenInUse {
+                return .whenInUse
+            } else {
+                // At least one of the keys NSLocationAlwaysAndWhenInUseUsageDescription or NSLocationWhenInUseUsageDescription MUST
+                // be present in the Info.plist file to use location services on iOS 11+.
+                fatalError("To use location services in iOS 11+, your Info.plist must provide a value for either NSLocationWhenInUseUsageDescription or NSLocationAlwaysAndWhenInUseUsageDescription.")
 			}
 		}
 	}
@@ -270,8 +273,7 @@ public extension CLLocationManager {
 			}
 			return hasPlistValue(forKey: "NSLocationAlwaysAndWhenInUseUsageDescription")
 		case .whenInUse:
-			if osVersion < 11 { return hasPlistValue(forKey: "NSLocationWhenInUseUsageDescription") }
-			return hasPlistValue(forKey: "NSLocationAlwaysAndWhenInUseUsageDescription")
+			return hasPlistValue(forKey: "NSLocationWhenInUseUsageDescription")
 		}
 	}
 	


### PR DESCRIPTION
The NSLocationAlwaysAndWhenInUseUsageDescription key is only required in iOS 11 when using Always, for WhenInUse there was no change in iOS 11. This PR allows this library to be used with an app that only uses WhenInUse, currently Always is required to avoid the fatalError in iOS 11.

https://developer.apple.com/documentation/corelocation/choosing_the_authorization_level_for_location_services/requesting_when_in_use_authorization