### PR TITLE
Migrate to swift 4.1 and fix callback overwriting bug

### DIFF
--- a/Sources/FindPlaceRequest.swift
+++ b/Sources/FindPlaceRequest.swift
@@ -235,7 +235,7 @@ public class PlaceMatch {
 	}
 	
 	public static func load(list: [JSON]) -> [PlaceMatch] {
-		return list.flatMap { PlaceMatch($0) }
+        return list.compactMap { PlaceMatch($0) }
 	}
 	
 	public func detail(timeout: TimeInterval? = nil,

--- a/Sources/Locator.swift
+++ b/Sources/Locator.swift
@@ -67,11 +67,10 @@ public class LocatorManager: NSObject, CLLocationManagerDelegate {
 		/// - Parameter callback: callback to call
 		/// - Returns: token used to remove the listener in a second time.
 		public func listen(forAuthChanges callback: @escaping AuthorizationDidChangeEvent) -> Token {
-			var (next,overflow) = self.nextTokenID.addingReportingOverflow(1)
-			if overflow {
-				next = 0
-			}
-			self.callbacks[next] = callback
+			var (next,overflow) = nextTokenID.addingReportingOverflow(1)
+			if overflow { next = 0 }
+			callbacks[next] = callback
+			nextTokenID = next
 			return next
 		}
 		

--- a/Sources/Shared.swift
+++ b/Sources/Shared.swift
@@ -829,7 +829,7 @@ public class Place: CustomStringConvertible {
 	}
 	
 	internal static func load(placemarks: [CLPlacemark]) -> [Place] {
-		return placemarks.flatMap { Place(placemark: $0) }
+        return placemarks.compactMap { Place(placemark: $0) }
 	}
 	
 	public var description: String {


### PR DESCRIPTION
There was a bug with overwriting callbacks that listen for "authorizationDidChangeEvent". Each time instead of adding callback to callbacks array, function "listen(forAuthChanges callback: @Escaping AuthorizationDidChangeEvent)" write new callback at index 1 of array callbacks. I fix it by assigning new value to nextTokenID variable.