### PR TITLE
Set the correct variable subThoroughfare instead of subAdministrative…

### DIFF
--- a/Sources/Shared.swift
+++ b/Sources/Shared.swift
@@ -817,7 +817,7 @@ public class Place: CustomStringConvertible {
 
 		self.postalCode = p.postalCode
 		self.thoroughfare = p.thoroughfare
-		self.subAdministrativeArea = p.subThoroughfare
+		self.subThoroughfare = p.subThoroughfare
 		
 		if #available(iOS 11.0, *) {
 			if let address = p.postalAddress {


### PR DESCRIPTION
In the code I noticed the following lines

self.subAdministrativeArea = p.subAdministrativeArea
.
.
.
.
self.subAdministrativeArea = p.subThoroughfare
Note that subAdministrativeArea is being overwritten to subThoroughfare and not p.subAdministrativeArea so I assume the wrong variable was used in this case