### PR TITLE
Resolving Listener bug

### DIFF
--- a/Sources/Locator.swift
+++ b/Sources/Locator.swift
@@ -72,6 +72,7 @@ public class LocatorManager: NSObject, CLLocationManagerDelegate {
 				next = 0
 			}
 			self.callbacks[next] = callback
+			self.nextTokenID = next
 			return next
 		}
 		


### PR DESCRIPTION
The Locator.events.listener function doesn't set the newly generated token to nextTokenID. As a result, the events can effectively only hold one callback.