### PR TITLE
Store the location in the request even if under thresh

### DIFF
--- a/Sources/Locator.swift
+++ b/Sources/Locator.swift
@@ -578,9 +578,9 @@ public class LocatorManager: NSObject, CLLocationManagerDelegate {
 						self.processRecurringRequest($0)
 					} else {
 						// This is a regular one-time location request
+						$0.location = location
 						if $0.hasValidThrehsold(forLocation: mostRecent) {
 							// The request's desired accuracy has been reached, complete it
-							$0.location = location
 							self.completeLocationRequest($0)
 						}
 					}


### PR DESCRIPTION
When a location arrives that is worse than the threshold, it is discarded. This PR changes this and stores it in the request. This way, if the request times out or fails, the request executes the "fail" completion block, but includes a location that can be used in the failed block - allowing the developer to decide what to do with it.
