### PR TITLE
Added minimum version to SPM file 

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "SwiftLocation",
     platforms: [
-        .iOS(.v9)
+        .iOS("9.3")
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.

--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,9 @@ import PackageDescription
 
 let package = Package(
     name: "SwiftLocation",
+    platforms: [
+        .iOS(.v9)
+    ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(


### PR DESCRIPTION
This should fix the minimum requirements error that pops up when adding the library through swift package manager.


Please add tag after merging. 