### PR TITLE
Add check for targetEnvironment(macCatalyst)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Would you contribute to the project? There are some interesting area of the proj
 
 - [ ] Region Monitoring
 - [ ] MapBox Support for geocoding/reverse and autocomplete
-- [ ] Beacon Monitoring
+- [x] Beacon Monitoring
 - [ ] freeGeoIP and smartIP support for IP to location discovery
 
 Any other idea for improvements? Fell free to open a PR!

--- a/Sources/SwiftLocation/LocationManager.swift
+++ b/Sources/SwiftLocation/LocationManager.swift
@@ -745,6 +745,7 @@ extension LocationManager: CLLocationManagerDelegate {
         }
     }
     
+    #if !targetEnvironment(macCatalyst)
     public func locationManager(_ manager: CLLocationManager, didStartMonitoringFor region: CLRegion) {
         let hasRequestsForRegion = queueBeaconsRequests.filter ({ $0.id == region.identifier }).count > 0
         if hasRequestsForRegion, let region = region as? CLBeaconRegion {
@@ -757,4 +758,5 @@ extension LocationManager: CLLocationManagerDelegate {
             request.complete(beacons: beacons)
         }
     }
+    #endif
 }


### PR DESCRIPTION
So it will compile with macCatalyst. These methods are not supported in macCatalyst and needs to be ignored.