### PR TITLE
- make OpenStreetOptions init public, to be able to use it via CocoaPods

### DIFF
--- a/Sources/SwiftLocation/Geocoding/Geocoder+Support.swift
+++ b/Sources/SwiftLocation/Geocoding/Geocoder+Support.swift
@@ -147,7 +147,7 @@ public extension GeocoderRequest {
             }
         }
         
-        override init() {
+        public override init() {
             super.init()
             self.params["limit"] = "10"
             self.params["addressdetails"] = "1"


### PR DESCRIPTION
OpenStreetOptions init is not available when using this library via CocoaPods, by default init of OpenStreetOptions is internal.

`'GeocoderRequest.OpenStreetOptions' initializer is inaccessible due to 'internal' protection level`

https://docs.swift.org/swift-book/LanguageGuide/AccessControl.html#ID21