### PR TITLE
kCLDistanceFilterNone value used as default for minDistance.

### DIFF
--- a/Sources/SwiftLocation/CLLocationManager/LocationManagerImpProtocol.swift
+++ b/Sources/SwiftLocation/CLLocationManager/LocationManagerImpProtocol.swift
@@ -152,7 +152,7 @@ public struct LocationManagerSettings: CustomStringConvertible, Equatable {
     public internal(set) var accuracy: GPSLocationOptions.Accuracy = .any
     
     /// Minimum distance.
-    public internal(set) var minDistance: CLLocationDistance?
+    public internal(set) var minDistance: CLLocationDistance = kCLDistanceFilterNone
     
     /// Activity type.
     public internal(set) var activityType: CLActivityType = .other
@@ -168,7 +168,7 @@ public struct LocationManagerSettings: CustomStringConvertible, Equatable {
         let data: [String: Any] = [
             "services": activeServices.description,
             "accuracy": accuracy.description,
-            "minDistance": minDistance ?? -1,
+            "minDistance": minDistance,
             "activityType": activityType.description
         ]
         return JSONStringify(data)

--- a/Sources/SwiftLocation/Extensions/CLLocationManager+Extension.swift
+++ b/Sources/SwiftLocation/Extensions/CLLocationManager+Extension.swift
@@ -80,7 +80,7 @@ internal extension CLLocationManager {
     func setSettings(_ settings: LocationManagerSettings) {
         self.desiredAccuracy = settings.accuracy.value
         self.activityType = settings.activityType
-        self.distanceFilter = settings.minDistance ?? kCLLocationAccuracyThreeKilometers
+        self.distanceFilter = settings.minDistance
                 
         // Location updates
         let hasContinousLocation = settings.activeServices.contains(.continousLocation)

--- a/Sources/SwiftLocation/Request/Requests/GPSLocation/GPSLocationOptions.swift
+++ b/Sources/SwiftLocation/Request/Requests/GPSLocation/GPSLocationOptions.swift
@@ -246,9 +246,9 @@ public class GPSLocationOptions: CustomStringConvertible, Codable {
     public var activityType: CLActivityType = .other
     
     /// Minimum horizontal distance to report new fresh data.
-    /// By default is set to `nil` which means no filter is applied.
-    public var minDistance: CLLocationDistance?
-    
+    /// By default is set to `kCLDistanceFilterNone` which means client will be informed of any movement.
+    public var minDistance: CLLocationDistance = kCLDistanceFilterNone
+
     /// Minimum time interval since last valid received data to report new fresh data.
     /// By default is set to `nil` which means no filter is applied.
     public var minTimeInterval: TimeInterval?
@@ -260,7 +260,7 @@ public class GPSLocationOptions: CustomStringConvertible, Codable {
             "accuracy= \(accuracy)",
             "timeout= \(timeout?.description ?? "none")",
             "activityType= \(activityType)",
-            "minDistance= \(minDistance ?? -1)",
+            "minDistance= \(minDistance)",
             "minTimeInterval= \(minTimeInterval ?? 0)"
         ].joined(separator: ", ") + "}"
     }
@@ -300,7 +300,7 @@ public class GPSLocationOptions: CustomStringConvertible, Codable {
         self.timeout = try container.decode(Timeout.self, forKey: .timeout)
         self.activityType = try CLActivityType(rawValue: container.decode(Int.self, forKey: .activityType)) ?? .other
         self.minTimeInterval = try container.decodeIfPresent(TimeInterval.self, forKey: .minTimeInterval)
-        self.minDistance = try container.decodeIfPresent(CLLocationDistance.self, forKey: .minDistance)
+        self.minDistance = try container.decodeIfPresent(CLLocationDistance.self, forKey: .minDistance) ?? kCLDistanceFilterNone
     }
     
 }

--- a/Sources/SwiftLocation/Request/Requests/GPSLocation/GPSLocationRequest.swift
+++ b/Sources/SwiftLocation/Request/Requests/GPSLocation/GPSLocationRequest.swift
@@ -141,8 +141,8 @@ public class GPSLocationRequest: RequestProtocol, Codable {
         }
         
         if let previousLocation = lastLocation {
-            if let minDistance = options.minDistance,
-               previousLocation.distance(from: data) > minDistance {
+            if options.minDistance > kCLDistanceFilterNone,
+               previousLocation.distance(from: data) > options.minDistance {
                 return .notMinDistance // minimum distance since last location is not respected.
             }
             

--- a/Sources/SwiftLocation/SwiftLocation.swift
+++ b/Sources/SwiftLocation/SwiftLocation.swift
@@ -534,7 +534,7 @@ public class LocationManager: LocationManagerDelegate, CustomStringConvertible {
             services.insert(request.options.subscription.service)
             
             settings.accuracy = min(settings.accuracy, request.options.accuracy)
-            settings.minDistance = min(settings.minDistance ?? -1, request.options.minDistance ?? -1)
+            settings.minDistance = max(settings.minDistance, request.options.minDistance)
             settings.activityType = CLActivityType(rawValue: max(settings.activityType.rawValue, request.options.activityType.rawValue)) ?? .other
         }
         
@@ -558,7 +558,6 @@ public class LocationManager: LocationManagerDelegate, CustomStringConvertible {
             services.insert(.beacon)
         }
         
-        if settings.minDistance == -1 { settings.minDistance = nil }
         settings.activeServices = services
         
         return settings

--- a/SwiftLocationPlayground/SwiftLocationPlayground/View Controllers/Features/Location by GPS/GPSController.swift
+++ b/SwiftLocationPlayground/SwiftLocationPlayground/View Controllers/Features/Location by GPS/GPSController.swift
@@ -88,7 +88,7 @@ class GPSController: UIViewController, UITableViewDelegate, UITableViewDataSourc
         case .activityType:
             cell.valueLabel.text = serviceOptions.activityType.description
         case .minDistance:
-            cell.valueLabel.text = serviceOptions.minDistance?.formattedValue ?? NOT_SET
+            cell.valueLabel.text = (serviceOptions.minDistance == kCLDistanceFilterNone) ? NOT_SET : serviceOptions.minDistance.formattedValue
         case .minTimeInterval:
             cell.valueLabel.text = serviceOptions.minTimeInterval?.format() ?? NOT_SET
         case .subscription:
@@ -157,7 +157,7 @@ class GPSController: UIViewController, UITableViewDelegate, UITableViewDataSourc
     
     private func selectMinDistance() {
         UIAlertController.showDoubleInput(title: "Select Minimum Distance", message: "Minimum horizontal distance to report new fresh data (meters)") { [weak self] value in
-            self?.serviceOptions.minDistance = (value != nil ? CLLocationDistance(value!) : nil)
+            self?.serviceOptions.minDistance = (value != nil ? CLLocationDistance(value!) : kCLDistanceFilterNone)
             self?.reloadData()
         }
     }

--- a/SwiftLocationPlayground/SwiftLocationPlayground/View Controllers/Requests List/RequestListController.swift
+++ b/SwiftLocationPlayground/SwiftLocationPlayground/View Controllers/Requests List/RequestListController.swift
@@ -248,7 +248,7 @@ fileprivate class ListData {
         managerSettings = [
             (.activeServices, settings.activeServices.isEmpty ? NOT_SET : settings.activeServices.description),
             (.accuracy, settings.accuracy.description),
-            (.minDistance, settings.minDistance?.formattedValue ?? NOT_SET),
+            (.minDistance, settings.minDistance.formattedValue),
             (.activityType, settings.activityType.description)
         ]
     }
@@ -298,7 +298,7 @@ fileprivate extension RequestProtocol {
                 "› type: \(gps.options.subscription.description)",
                 "› accuracy: \(gps.options.accuracy.description)",
                 "› activity: \(gps.options.activityType.description)",
-                "› minDist: \(gps.options.minDistance?.description ?? NOT_SET)",
+                "› minDist: \(gps.options.minDistance.description)",
                 "› minInterval: \(gps.options.minTimeInterval?.description ?? NOT_SET)"
             ].joined(separator: "\n")
             


### PR DESCRIPTION
According to the current implementation, setting minDistance was not working. It was always setting the minDistance value to -1.

https://github.com/malcommac/SwiftLocation/blob/9f9a81b084afac692e26b213bca5715271bf6f25/Sources/SwiftLocation/SwiftLocation.swift#L537

Moreover, it is better using the default value of the distanceFilter of CLLocationManager. Therefore, i have updated the code to use it as default.