### PR TITLE
Fix incorrect nonDetermined status handling causing unauthorized error for one shot requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ SwiftLocation.gpsLocation().then {
 }
 ```
 
+**Remember**: Before using SwiftLocation you should set the appropriate keys in your Info.plist (`NSLocationAlwaysAndWhenInUseUsageDescription` or `NSLocationWhenInUseUsageDescription` and `NSLocationTemporaryUsageDescriptionDictionary` if you are using reduced location in iOS 14+).
+
 If you need more customization you can fine-tune your request by configuring each of the available parameters. This is a more complex example: 
 
 ```swift

--- a/README.md
+++ b/README.md
@@ -440,9 +440,9 @@ func application(_ application: UIApplication, didFinishLaunchingWithOptions lau
 
 If you want to disable automatic requests save you can set the `SwiftLocation.automaticRequestSave = false`.
 
-<a name="installation"/>
+<a name="precisereducedlocation"/>
 
-- [Precise & Reduced Location in iOS 14+](#precisereducedlocation)
+## Precise & Reduced Location in iOS 14+
 
 Location data are very sensitive; since iOS 14 Apple introduced a further layer of privacy to Core Location Manager: **users can choose whether to give precise or approximate location access**.  
 Since 5.0.1 SwiftLocation supports this options and it's transparent to old iOS versions.  

--- a/Sources/SwiftLocation/Extensions/CLLocationManager+Extension.swift
+++ b/Sources/SwiftLocation/Extensions/CLLocationManager+Extension.swift
@@ -146,6 +146,15 @@ extension CLAuthorizationStatus: CustomStringConvertible {
             return false
         }
     }
+
+    internal var isRejected: Bool {
+        switch self {
+        case .denied, .restricted:
+            return true
+        default:
+            return false
+        }
+    }
     
     public var description: String {
         switch self {

--- a/Sources/SwiftLocation/SwiftLocation.swift
+++ b/Sources/SwiftLocation/SwiftLocation.swift
@@ -551,7 +551,7 @@ public class LocationManager: LocationManagerDelegate, CustomStringConvertible {
     }
     
     private func failWeakAuthorizationRequests() {
-        guard authorizationStatus.isAuthorized == false else {
+        guard authorizationStatus.isRejected == true else {
             // If we have already the authorization even request with `avoidRequestAuthorization = true`
             // may receive notifications of locations.
             return

--- a/SwiftLocationPlayground/SwiftLocationPlayground/View Controllers/Features/Location by GPS/GPSController.swift
+++ b/SwiftLocationPlayground/SwiftLocationPlayground/View Controllers/Features/Location by GPS/GPSController.swift
@@ -232,6 +232,7 @@ class GPSController: UIViewController, UITableViewDelegate, UITableViewDataSourc
         let request = SwiftLocation.gpsLocationWith(serviceOptions)
         
         serviceOptions = GPSLocationOptions()
+        serviceOptions.avoidRequestAuthorization = true
         reloadData()
         
         AppDelegate.attachSubscribersToGPS([request])


### PR DESCRIPTION
I believe that nonDetermined status should not cause unauthorized error when using one shot request on gps
I added check on reject action so nonDetermined will be treated as ok status 