### PR TITLE
Initialize service with default apiKey instead of using empty string

### DIFF
--- a/SwiftLocationPlayground/SwiftLocationPlayground/View Controllers/Features/Autocomplete/AutocompleteController.swift
+++ b/SwiftLocationPlayground/SwiftLocationPlayground/View Controllers/Features/Autocomplete/AutocompleteController.swift
@@ -339,12 +339,12 @@ public class AutocompleteController: UIViewController, UITableViewDelegate, UITa
                 self?.reloadData()
             }),
             ("Google", { [weak self] _ in
-                self?.currentService = Autocomplete.Google(partialMatches: "", APIKey: "")
+                self?.currentService = Autocomplete.Google(partialMatches: "")
                 self?.selectAutocompleteAddress()
                 self?.reloadData()
             }),
             ("Here", { [weak self] _ in
-                self?.currentService = Autocomplete.Here(partialMatches: "", APIKey: "")
+                self?.currentService = Autocomplete.Here(partialMatches: "")
                 self?.selectAutocompleteAddress()
                 self?.reloadData()
             })


### PR DESCRIPTION
Small fix for playground. If a user pasted their api key in credential store, autocomplete would ignore that, requiring them to enter it manually again in AutoCompleteController. 