### PR TITLE
Fixed OpenStreet reverse geocoding and JSON parsing

### DIFF
--- a/Sources/SwiftLocation/Request/Requests/Geocoder/Services/Geocoder-OpenStreet.swift
+++ b/Sources/SwiftLocation/Request/Requests/Geocoder/Services/Geocoder-OpenStreet.swift
@@ -151,7 +151,7 @@ public extension Geocoder {
                 url = URL(string: "https://nominatim.openstreetmap.org/reverse")!
                 queryItems.append(contentsOf: [
                     URLQueryItem(name: "lat", value: String(coordinates.latitude)),
-                    URLQueryItem(name: "lon", value: String(coordinates.latitude)),
+                    URLQueryItem(name: "lon", value: String(coordinates.longitude)),
                 ])
             }
             

--- a/Sources/SwiftLocation/Request/Support Structures/GeoLocation/GeoLocation+OpenStreet.swift
+++ b/Sources/SwiftLocation/Request/Support Structures/GeoLocation/GeoLocation+OpenStreet.swift
@@ -83,7 +83,15 @@ internal extension GeoLocation {
     static func fromOpenStreetList(_ data: Data) throws -> [GeoLocation] {
         let rawJSON = try JSONSerialization.jsonObject(with: data, options: .allowFragments)
         
-        guard let rawResults = rawJSON as? [[String: Any]] else {
+        var rawResults = [[String: Any]]()
+        if let result = rawJSON as? [String: Any] {
+            // https://nominatim.org/release-docs/develop/api/Reverse/
+            // OpenStreet Reverse Geocoding returns exactly one result or an error when the coordinate is in an area with no OSM data coverage.
+            rawResults.append(result)
+        } else if let results = rawJSON as? [[String: Any]] {
+            // OpenStreet Forward Geocoding return multiple results
+            rawResults = results
+        } else {
             throw LocationError.parsingError
         }
         


### PR DESCRIPTION
I found few problems with OpenStreet geocoding:

- Request made to reverse geocoding used `latitude` field for both `lat` and `lon` properties
- JSON was not parsed for reverse geocoding response, because reverse return single result and forward returns multiple results as per documentation: https://nominatim.org/release-docs/develop/api/Reverse/

This PR fixes both issues.
Thank you 🤝 