### PR TITLE
Update class name for version so it doesn't conflict with the module name

### DIFF
--- a/Sources/SwiftLocation/SwiftLocation.swift
+++ b/Sources/SwiftLocation/SwiftLocation.swift
@@ -25,9 +25,9 @@
 
 import Foundation
 
-public class SwiftLocation {
+public class SwiftLocationVersion {
     
     /// Version of the SDK.
-    public static let version = "6.0.0"
+    public static let version = "6.0.1"
         
 }


### PR DESCRIPTION
This PR resolves the module / class name conflict that makes it difficult to use if we need to specify the module for the class Location.