### PR TITLE
CoreLocation returns .notDetermined before Pop Up Button is pressed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,16 @@ concurrency:
   
 jobs:
   ios-latest:
-    name: Unit Tests (iOS 16.4, Xcode 14.3.1)
-    runs-on: macOS-13
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_14.3.1.app/Contents/Developer
+    name: Unit Tests (iOS 17.5, Xcode 15.4)
+    runs-on: macos-14
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-xcode@v3
+        with:
+            xcode-version: '15.4'
       - name: Run Tests
         run: |
-          Scripts/test.sh -s "SwiftLocation" -d "OS=16.4,name=iPhone 14 Pro"
+          Scripts/test.sh -s "SwiftLocation" -d "platform=iOS Simulator,OS=17.5,name=iPhone 15 Pro"
  # macos-latest:
  #   name: Unit Tests (macOS, Xcode 14.3.1)
  #   runs-on: macOS-13
@@ -33,12 +34,13 @@ jobs:
  #     - name: Run Tests
  #       run: Scripts/test.sh -d "platform=macOS"
   tvos-latest:
-    name: Unit Tests (tvOS 16.4, Xcode 14.3.1)
-    runs-on: macOS-13
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_14.3.1.app/Contents/Developer
+    name: Unit Tests (tvOS 17.5, Xcode 15.4)
+    runs-on: macos-14
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-xcode@v3
+        with:
+            xcode-version: '15.4'
       - name: Run Tests
         run: |
-          Scripts/test.sh -s "SwiftLocation" -d "OS=16.4,name=Apple TV"
+          Scripts/test.sh -s "SwiftLocation" -d "platform=tvOS Simulator,OS=17.5,name=Apple TV 4K (3rd generation)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,16 @@ concurrency:
   
 jobs:
   ios-latest:
-    name: Unit Tests (iOS 17.5, Xcode 15.4)
-    runs-on: macos-14
+    name: Unit Tests (iOS 26.0, Xcode 26.0.1)
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '15.4'
+          xcode-version: '26.0.1'
       - name: Run Tests
         run: |
-          Scripts/test.sh -s "SwiftLocation" -d "platform=iOS Simulator,OS=17.5,name=iPhone 15 Pro"
+          Scripts/test.sh -s "SwiftLocation" -d "platform=iOS Simulator,OS=26.0,name=iPhone 17 Pro"
  # macos-latest:
  #   name: Unit Tests (macOS, Xcode 14.3.1)
  #   runs-on: macOS-13
@@ -34,13 +34,13 @@ jobs:
  #     - name: Run Tests
  #       run: Scripts/test.sh -d "platform=macOS"
   tvos-latest:
-    name: Unit Tests (tvOS 17.5, Xcode 15.4)
-    runs-on: macos-14
+    name: Unit Tests (tvOS 26.0, Xcode 26.0.1)
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '15.4'
+          xcode-version: '26.0.1'
       - name: Run Tests
         run: |
-          Scripts/test.sh -s "SwiftLocation" -d "platform=tvOS Simulator,OS=17.5,name=Apple TV 4K (3rd generation)"
+          Scripts/test.sh -s "SwiftLocation" -d "platform=tvOS Simulator,OS=26.0,name=Apple TV 4K (3rd generation)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           xcode-version: '26.0.1'
       - name: Run Tests
         run: |
-          Scripts/test.sh -s "SwiftLocation" -d "platform=iOS Simulator,OS=26.0,name=iPhone 17 Pro"
+          Scripts/test.sh -s "SwiftLocation" -d "platform=iOS Simulator,name=iPhone 17 Pro"
  # macos-latest:
  #   name: Unit Tests (macOS, Xcode 14.3.1)
  #   runs-on: macOS-13
@@ -43,4 +43,4 @@ jobs:
           xcode-version: '26.0.1'
       - name: Run Tests
         run: |
-          Scripts/test.sh -s "SwiftLocation" -d "platform=tvOS Simulator,OS=26.0,name=Apple TV 4K (3rd generation)"
+          Scripts/test.sh -s "SwiftLocation" -d "platform=tvOS Simulator,name=Apple TV 4K (3rd generation)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-xcode@v3
+      - uses: maxim-lobanov/setup-xcode@v1
         with:
-            xcode-version: '15.4'
+          xcode-version: '15.4'
       - name: Run Tests
         run: |
           Scripts/test.sh -s "SwiftLocation" -d "platform=iOS Simulator,OS=17.5,name=iPhone 15 Pro"
@@ -38,9 +38,9 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-xcode@v3
+      - uses: maxim-lobanov/setup-xcode@v1
         with:
-            xcode-version: '15.4'
+          xcode-version: '15.4'
       - name: Run Tests
         run: |
           Scripts/test.sh -s "SwiftLocation" -d "platform=tvOS Simulator,OS=17.5,name=Apple TV 4K (3rd generation)"

--- a/Package.swift
+++ b/Package.swift
@@ -9,13 +9,13 @@ let package = Package(
     products: [
         .library(
             name: "SwiftLocation",
-            targets: ["SwiftLocation"]),
+            targets: ["SwiftLocation"])
     ],
     targets: [
         .target(
             name: "SwiftLocation"),
         .testTarget(
             name: "SwiftLocationTests",
-            dependencies: ["SwiftLocation"]),
+            dependencies: ["SwiftLocation"])
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version: 5.5
+// swift-tools-version: 5.10
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "SwiftLocation",
-    platforms: [.iOS(.v14), .macOS(.v11), .watchOS(.v7), .tvOS(.v14)],
+    platforms: [.iOS(.v16), .macOS(.v11), .watchOS(.v7), .tvOS(.v14)],
     products: [
         .library(
             name: "SwiftLocation",

--- a/Sources/SwiftLocation/Async Tasks/AccuracyAuthorization.swift
+++ b/Sources/SwiftLocation/Async Tasks/AccuracyAuthorization.swift
@@ -27,9 +27,9 @@ import Foundation
 import CoreLocation
 
 extension Tasks {
-    
+
     public final class AccuracyAuthorization: AnyTask {
-        
+
         // MARK: - Support Structures
 
         /// Stream produced by the task.
@@ -37,10 +37,10 @@ extension Tasks {
 
         /// The event produced by the stream.
         public enum StreamEvent: CustomStringConvertible, Equatable {
-            
+
             /// A new change in accuracy level authorization has been captured.
             case didUpdateAccuracyAuthorization(_ accuracyAuthorization: CLAccuracyAuthorization)
-            
+
             /// Return the accuracy authorization of the event
             var accuracyAuthorization: CLAccuracyAuthorization {
                 switch self {
@@ -48,22 +48,22 @@ extension Tasks {
                     return accuracyAuthorization
                 }
             }
-            
+
             public var description: String {
                 switch self {
                 case .didUpdateAccuracyAuthorization:
                     return "didUpdateAccuracyAuthorization"
                 }
             }
-            
+
         }
-        
+
         // MARK: - Public Properties
 
         public let uuid = UUID()
         public var stream: Stream.Continuation?
         public var cancellable: CancellableTask?
-        
+
         // MARK: - Functions
 
         public func receivedLocationManagerEvent(_ event: LocationManagerBridgeEvent) {
@@ -75,5 +75,5 @@ extension Tasks {
             }
         }
     }
-    
+
 }

--- a/Sources/SwiftLocation/Async Tasks/AccuracyPermission.swift
+++ b/Sources/SwiftLocation/Async Tasks/AccuracyPermission.swift
@@ -27,31 +27,31 @@ import Foundation
 import CoreLocation
 
 extension Tasks {
-    
+
     public final class AccuracyPermission: AnyTask {
-        
+
         // MARK: - Support Structures
 
         public typealias Continuation = CheckedContinuation<CLAccuracyAuthorization, Error>
-        
+
         // MARK: - Public Properties
 
         public let uuid = UUID()
         public var cancellable: CancellableTask?
         var continuation: Continuation?
-        
+
         // MARK: - Private Properties
 
         private weak var instance: Location?
-        
+
         // MARK: - Initialization
 
         init(instance: Location) {
             self.instance = instance
         }
-        
+
         // MARK: - Functions
-        
+
         public func receivedLocationManagerEvent(_ event: LocationManagerBridgeEvent) {
             switch event {
             case .didChangeAccuracyAuthorization(let auth):
@@ -60,29 +60,29 @@ extension Tasks {
                 break
             }
         }
-        
+
         @MainActor
         func requestTemporaryPermission(purposeKey: String) async throws -> CLAccuracyAuthorization {
             try await withCheckedThrowingContinuation { continuation in
                 guard let instance = self.instance else { return }
-                
+
                 guard instance.locationManager.locationServicesEnabled() else {
                     continuation.resume(throwing: LocationErrors.locationServicesDisabled)
                     return
                 }
-                
+
                 let authorizationStatus = instance.authorizationStatus
                 guard authorizationStatus != .notDetermined else {
                     continuation.resume(throwing: LocationErrors.authorizationRequired)
                     return
                 }
-                
+
                 let accuracyAuthorization = instance.accuracyAuthorization
                 guard accuracyAuthorization != .fullAccuracy else {
                     continuation.resume(with: .success(accuracyAuthorization))
                     return
                 }
-                
+
                 self.continuation = continuation
                 instance.asyncBridge.add(task: self)
                 instance.locationManager.requestTemporaryFullAccuracyAuthorization(withPurposeKey: purposeKey) { error in
@@ -90,7 +90,7 @@ extension Tasks {
                         continuation.resume(throwing: error)
                         return
                     }
-                    
+
                     // If the user chooses reduced accuracy, the didChangeAuthorization delegate method will not called.
                     if instance.locationManager.accuracyAuthorization == .reducedAccuracy {
                         let accuracyAuthorization = instance.accuracyAuthorization
@@ -99,7 +99,7 @@ extension Tasks {
                 }
             }
         }
-        
+
     }
-    
+
 }

--- a/Sources/SwiftLocation/Async Tasks/AccuracyPermission.swift
+++ b/Sources/SwiftLocation/Async Tasks/AccuracyPermission.swift
@@ -61,6 +61,7 @@ extension Tasks {
             }
         }
         
+        @MainActor
         func requestTemporaryPermission(purposeKey: String) async throws -> CLAccuracyAuthorization {
             try await withCheckedThrowingContinuation { continuation in
                 guard let instance = self.instance else { return }

--- a/Sources/SwiftLocation/Async Tasks/AccuracyPermission.swift
+++ b/Sources/SwiftLocation/Async Tasks/AccuracyPermission.swift
@@ -63,13 +63,16 @@ extension Tasks {
 
         @MainActor
         func requestTemporaryPermission(purposeKey: String) async throws -> CLAccuracyAuthorization {
-            try await withCheckedThrowingContinuation { continuation in
+            guard let instance = self.instance else {
+                throw LocationErrors.noLocation
+            }
+            
+            guard await instance.locationManager.locationServicesEnabled() else {
+                throw LocationErrors.locationServicesDisabled
+            }
+            
+            return try await withCheckedThrowingContinuation { continuation in
                 guard let instance = self.instance else { return }
-
-                guard instance.locationManager.locationServicesEnabled() else {
-                    continuation.resume(throwing: LocationErrors.locationServicesDisabled)
-                    return
-                }
 
                 let authorizationStatus = instance.authorizationStatus
                 guard authorizationStatus != .notDetermined else {

--- a/Sources/SwiftLocation/Async Tasks/AnyTask.swift
+++ b/Sources/SwiftLocation/Async Tasks/AnyTask.swift
@@ -27,6 +27,7 @@ import Foundation
 
 public enum Tasks { }
 
+@MainActor
 public protocol AnyTask: AnyObject {
     
     var cancellable: CancellableTask? { get set }
@@ -50,7 +51,7 @@ public extension AnyTask {
     
 }
 
-
+@MainActor
 public protocol CancellableTask: AnyObject {
     
     func cancel(task: any AnyTask)

--- a/Sources/SwiftLocation/Async Tasks/AnyTask.swift
+++ b/Sources/SwiftLocation/Async Tasks/AnyTask.swift
@@ -29,31 +29,31 @@ public enum Tasks { }
 
 @MainActor
 public protocol AnyTask: AnyObject {
-    
+
     var cancellable: CancellableTask? { get set }
     var uuid: UUID { get }
     var taskType: ObjectIdentifier { get }
-    
+
     func receivedLocationManagerEvent(_ event: LocationManagerBridgeEvent)
     func didCancelled()
     func willStart()
-    
+
 }
 
 public extension AnyTask {
-    
+
     var taskType: ObjectIdentifier {
         ObjectIdentifier(Self.self)
     }
-    
+
     func didCancelled() { }
     func willStart() { }
-    
+
 }
 
 @MainActor
 public protocol CancellableTask: AnyObject {
-    
+
     func cancel(task: any AnyTask)
-    
+
 }

--- a/Sources/SwiftLocation/Async Tasks/Authorization.swift
+++ b/Sources/SwiftLocation/Async Tasks/Authorization.swift
@@ -27,9 +27,9 @@ import Foundation
 import CoreLocation
 
 extension Tasks {
-    
+
     public final class Authorization: AnyTask {
-        
+
         // MARK: - Support Structures
 
         /// Stream produced by the task.
@@ -37,10 +37,10 @@ extension Tasks {
 
         /// The event produced by the stream.
         public enum StreamEvent {
-            
+
             /// Authorization did change with a new value
             case didChangeAuthorization(_ status: CLAuthorizationStatus)
-            
+
             /// The current status of the authorization.
             public var authorizationStatus: CLAuthorizationStatus {
                 switch self {
@@ -48,15 +48,15 @@ extension Tasks {
                     return status
                 }
             }
-            
+
         }
-        
+
         // MARK: - Public Properties
 
         public let uuid = UUID()
         public var stream: Stream.Continuation?
         public var cancellable: CancellableTask?
-        
+
         // MARK: - Functions
 
         public func receivedLocationManagerEvent(_ event: LocationManagerBridgeEvent) {
@@ -68,5 +68,5 @@ extension Tasks {
             }
         }
     }
-    
+
 }

--- a/Sources/SwiftLocation/Async Tasks/BeaconMonitoring.swift
+++ b/Sources/SwiftLocation/Async Tasks/BeaconMonitoring.swift
@@ -28,33 +28,33 @@ import CoreLocation
 
 #if !os(watchOS) && !os(tvOS)
 extension Tasks {
-    
+
     public final class BeaconMonitoring: AnyTask {
-        
+
         // MARK: - Support Structures
 
         /// The event produced by the stream.
         public typealias Stream = AsyncStream<StreamEvent>
-        
+
         /// The event produced by the stream.
         public enum StreamEvent: CustomStringConvertible, Equatable {
             case didRange(beacons: [CLBeacon], constraint: CLBeaconIdentityConstraint)
             case didFailRanginFor(constraint: CLBeaconIdentityConstraint, error: Error)
-            
+
             public static func == (lhs: Tasks.BeaconMonitoring.StreamEvent, rhs: Tasks.BeaconMonitoring.StreamEvent) -> Bool {
                 switch (lhs, rhs) {
                 case (let .didRange(b1, _), let .didRange(b2, _)):
                     return b1 == b2
-                    
+
                 case (let .didFailRanginFor(c1, _), let .didFailRanginFor(c2, _)):
                     return c1 == c2
-                    
+
                 default:
                     return false
-                    
+
                 }
             }
-            
+
             public var description: String {
                 switch self {
                 case .didFailRanginFor:
@@ -64,20 +64,20 @@ extension Tasks {
                 }
             }
         }
-        
+
         // MARK: - Public Properties
 
         public let uuid = UUID()
         public var stream: Stream.Continuation?
         public var cancellable: CancellableTask?
         public private(set) var satisfying: CLBeaconIdentityConstraint
-        
+
         // MARK: - Initialization
 
         init(satisfying: CLBeaconIdentityConstraint) {
             self.satisfying = satisfying
         }
-        
+
         // MARK: - Functions
 
         public func receivedLocationManagerEvent(_ event: LocationManagerBridgeEvent) {
@@ -90,8 +90,8 @@ extension Tasks {
                 break
             }
         }
-        
+
     }
-    
+
 }
 #endif

--- a/Sources/SwiftLocation/Async Tasks/ContinuousUpdateLocation.swift
+++ b/Sources/SwiftLocation/Async Tasks/ContinuousUpdateLocation.swift
@@ -27,37 +27,37 @@ import Foundation
 import CoreLocation
 
 extension Tasks {
-    
+
     public final class ContinuousUpdateLocation: AnyTask {
-        
+
         // MARK: - Support Structures
 
         /// Stream produced by the task.
         public typealias Stream = AsyncStream<StreamEvent>
-        
+
         /// The event produced by the stream.
         public enum StreamEvent: CustomStringConvertible, Equatable {
-            
+
             /// A new array of locations has been received.
             case didUpdateLocations(_ locations: [CLLocation])
-            
+
             /// Something went wrong while reading new locations.
             case didFailed(_ error: Error)
-            
+
             #if os(iOS)
             /// Location updates did resume.
             case didResume
-            
+
             /// Location updates did pause.
             case didPaused
             #endif
-            
+
             /// Return the location received by the event if it's a location event.
             /// In case of multiple events it will return the most recent one.
             public var location: CLLocation? {
                 locations?.max(by: { $0.timestamp < $1.timestamp })
             }
-            
+
             /// Return the list of locations received if the event is a location update.
             public var locations: [CLLocation]? {
                 guard case .didUpdateLocations(let locations) = self else {
@@ -65,7 +65,7 @@ extension Tasks {
                 }
                 return locations
             }
-            
+
             /// Error received if any.
             public var error: Error? {
                 guard case .didFailed(let e) = self else {
@@ -73,22 +73,22 @@ extension Tasks {
                 }
                 return e
             }
-            
+
             public var description: String {
                 switch self {
                 #if os(iOS)
-                case .didPaused: 
+                case .didPaused:
                     return "paused"
                 case .didResume:
                     return "resume"
                 #endif
-                case let .didFailed(e): 
+                case let .didFailed(e):
                     return "error \(e.localizedDescription)"
                 case let .didUpdateLocations(l):
                     return "\(l.count) locations"
                 }
             }
-            
+
             public static func == (lhs: Tasks.ContinuousUpdateLocation.StreamEvent, rhs: Tasks.ContinuousUpdateLocation.StreamEvent) -> Bool {
                 switch (lhs, rhs) {
                 case (.didFailed(let e1), .didFailed(let e2)):
@@ -106,23 +106,23 @@ extension Tasks {
                 }
             }
         }
-        
+
         // MARK: - Public Properties
-        
+
         public let uuid = UUID()
         public var stream: Stream.Continuation?
         public var cancellable: CancellableTask?
-        
+
         // MARK: - Private Properties
 
         private weak var instance: Location?
-        
+
         // MARK: - Initialization
 
         init(instance: Location) {
             self.instance = instance
         }
-        
+
         // MARK: - Functions
 
         public func receivedLocationManagerEvent(_ event: LocationManagerBridgeEvent) {
@@ -130,32 +130,31 @@ extension Tasks {
             #if os(iOS)
             case .locationUpdatesPaused:
                 stream?.yield(.didPaused)
-                
+
             case .locationUpdatesResumed:
                 stream?.yield(.didResume)
             #endif
-                
+
             case let .didFailWithError(error):
                 stream?.yield(.didFailed(error))
-                
+
             case let .receiveNewLocations(locations):
                 stream?.yield(.didUpdateLocations(locations))
-                
+
             default:
                 break
             }
         }
-        
+
         public func didCancelled() {
             guard let stream = stream else {
                 return
             }
-            
+
             stream.finish()
             self.stream = nil
         }
-        
+
     }
-    
-    
+
 }

--- a/Sources/SwiftLocation/Async Tasks/HeadingMonitoring.swift
+++ b/Sources/SwiftLocation/Async Tasks/HeadingMonitoring.swift
@@ -28,55 +28,55 @@ import CoreLocation
 
 #if os(iOS)
 extension Tasks {
-    
+
     public final class HeadingMonitoring: AnyTask {
-        
+
         // MARK: - Support Structures
 
         /// The event produced by the stream.
         public typealias Stream = AsyncStream<StreamEvent>
-        
+
         /// The event produced by the stream.
         public enum StreamEvent: CustomStringConvertible, Equatable {
-            
+
             /// A new heading value has been received.
             case didUpdateHeading(_ heading: CLHeading)
-            
+
             /// An error has occurred.
             case didFailWithError(_ error: Error)
-            
+
             public static func == (lhs: Tasks.HeadingMonitoring.StreamEvent, rhs: Tasks.HeadingMonitoring.StreamEvent) -> Bool {
                 switch (lhs, rhs) {
                 case (let .didUpdateHeading(h1), let .didUpdateHeading(h2)):
                     return h1 == h2
-                    
+
                 case (let .didFailWithError(e1), let .didFailWithError(e2)):
                     return e1.localizedDescription == e2.localizedDescription
-                    
+
                 default:
                     return false
-                    
+
                 }
             }
-            
+
             public var description: String {
                 switch self {
                 case .didFailWithError:
                     return "didFailWithError"
-                    
+
                 case .didUpdateHeading:
                     return "didUpdateHeading"
-                    
+
                 }
             }
         }
-        
+
         // MARK: - Public Properties
-        
+
         public let uuid = UUID()
         public var stream: Stream.Continuation?
         public var cancellable: CancellableTask?
-        
+
         // MARK: - Functions
 
         public func receivedLocationManagerEvent(_ event: LocationManagerBridgeEvent) {
@@ -89,8 +89,8 @@ extension Tasks {
                 break
             }
         }
-        
+
     }
-    
+
 }
 #endif

--- a/Sources/SwiftLocation/Async Tasks/LocatePermission.swift
+++ b/Sources/SwiftLocation/Async Tasks/LocatePermission.swift
@@ -60,6 +60,14 @@ extension Tasks {
                     return
                 }
                 
+                guard authorization != .notDetermined else {
+                    // The location manager can return .notDetermined before a user hits the location popup.
+                    // This causes the await to return before a user has tapped a button on the popup, so we
+                    // ignore it here. Once the user hits a button on the popup, receivedLocationManagerEvent will
+                    // be called again with a better authorization.
+                    return
+                }
+                
                 continuation.resume(returning: authorization)
                 self.continuation = nil
                 cancellable?.cancel(task: self)

--- a/Sources/SwiftLocation/Async Tasks/LocatePermission.swift
+++ b/Sources/SwiftLocation/Async Tasks/LocatePermission.swift
@@ -27,31 +27,31 @@ import Foundation
 import CoreLocation
 
 extension Tasks {
-    
+
     public final class LocatePermission: AnyTask {
-        
+
         // MARK: - Support Structures
 
         public typealias Continuation = CheckedContinuation<CLAuthorizationStatus, Error>
-        
+
         // MARK: - Public Properties
 
         public let uuid = UUID()
         public var cancellable: CancellableTask?
         var continuation: Continuation?
-        
+
         // MARK: - Private Properties
 
         private weak var instance: Location?
-        
+
         // MARK: - Initialization
 
         init(instance: Location) {
             self.instance = instance
         }
-        
+
         // MARK: - Functions
-        
+
         public func receivedLocationManagerEvent(_ event: LocationManagerBridgeEvent) {
             switch event {
             case .didChangeAuthorization(let authorization):
@@ -59,8 +59,7 @@ extension Tasks {
                     cancellable?.cancel(task: self)
                     return
                 }
-                
-                
+
                 guard authorization != .notDetermined else {
                     // The location manager can return .notDetermined before a user hits the location popup.
                     // This causes the await to return before a user has tapped a button on the popup, so we
@@ -68,8 +67,7 @@ extension Tasks {
                     // be called again with a better authorization.
                     return
                 }
-                 
-                
+
                 continuation.resume(returning: authorization)
                 self.continuation = nil
                 cancellable?.cancel(task: self)
@@ -81,25 +79,25 @@ extension Tasks {
         func requestWhenInUsePermission() async throws -> CLAuthorizationStatus {
             try await withCheckedThrowingContinuation { continuation in
                 guard let instance = self.instance else { return }
-                
+
                 let isAuthorized = instance.authorizationStatus != .notDetermined
                 guard !isAuthorized else {
                     continuation.resume(returning: instance.authorizationStatus)
                     return
                 }
-                
+
                 self.continuation = continuation
                 instance.asyncBridge.add(task: self)
                 instance.locationManager.requestWhenInUseAuthorization()
             }
         }
-        
+
         #if !os(tvOS)
         @MainActor
         func requestAlwaysPermission() async throws -> CLAuthorizationStatus {
             try await withCheckedThrowingContinuation { continuation in
                 guard let instance = self.instance else { return }
-                
+
                 #if os(macOS)
                 let isAuthorized = instance.authorizationStatus != .notDetermined
                 #else
@@ -109,14 +107,14 @@ extension Tasks {
                     continuation.resume(with: .success(instance.authorizationStatus))
                     return
                 }
-                
+
                 self.continuation = continuation
                 instance.asyncBridge.add(task: self)
                 instance.locationManager.requestAlwaysAuthorization()
             }
         }
         #endif
-        
+
     }
-    
+
 }

--- a/Sources/SwiftLocation/Async Tasks/LocatePermission.swift
+++ b/Sources/SwiftLocation/Async Tasks/LocatePermission.swift
@@ -60,6 +60,7 @@ extension Tasks {
                     return
                 }
                 
+                
                 guard authorization != .notDetermined else {
                     // The location manager can return .notDetermined before a user hits the location popup.
                     // This causes the await to return before a user has tapped a button on the popup, so we
@@ -67,6 +68,7 @@ extension Tasks {
                     // be called again with a better authorization.
                     return
                 }
+                 
                 
                 continuation.resume(returning: authorization)
                 self.continuation = nil
@@ -75,7 +77,7 @@ extension Tasks {
                 break
             }
         }
-        
+        @MainActor
         func requestWhenInUsePermission() async throws -> CLAuthorizationStatus {
             try await withCheckedThrowingContinuation { continuation in
                 guard let instance = self.instance else { return }
@@ -93,6 +95,7 @@ extension Tasks {
         }
         
         #if !os(tvOS)
+        @MainActor
         func requestAlwaysPermission() async throws -> CLAuthorizationStatus {
             try await withCheckedThrowingContinuation { continuation in
                 guard let instance = self.instance else { return }

--- a/Sources/SwiftLocation/Async Tasks/LocationServicesEnabled.swift
+++ b/Sources/SwiftLocation/Async Tasks/LocationServicesEnabled.swift
@@ -28,6 +28,7 @@ import CoreLocation
 
 extension Tasks {
     
+    @MainActor
     public final class LocationServicesEnabled: AnyTask {
         
         // MARK: - Support Structures

--- a/Sources/SwiftLocation/Async Tasks/LocationServicesEnabled.swift
+++ b/Sources/SwiftLocation/Async Tasks/LocationServicesEnabled.swift
@@ -27,21 +27,21 @@ import Foundation
 import CoreLocation
 
 extension Tasks {
-    
+
     @MainActor
     public final class LocationServicesEnabled: AnyTask {
-        
+
         // MARK: - Support Structures
-        
+
         /// Stream produced by the task.
         public typealias Stream = AsyncStream<StreamEvent>
-        
+
         /// The event produced by the stream.
         public enum StreamEvent: CustomStringConvertible, Equatable {
-            
+
             /// A new change in the location services status has been detected.
             case didChangeLocationEnabled(_ enabled: Bool)
-            
+
             /// Return `true` if location service is enabled.
             var isLocationEnabled: Bool {
                 switch self {
@@ -49,25 +49,25 @@ extension Tasks {
                     return enabled
                 }
             }
-            
+
             public var description: String {
                 switch self {
                 case .didChangeLocationEnabled:
                     return "didChangeLocationEnabled"
-                    
+
                 }
             }
-            
+
         }
-        
+
         // MARK: - Public Properties
-        
+
         public let uuid = UUID()
         public var stream: Stream.Continuation?
         public var cancellable: CancellableTask?
-        
+
         // MARK: - Functions
-        
+
         public func receivedLocationManagerEvent(_ event: LocationManagerBridgeEvent) {
             switch event {
             case .didChangeLocationEnabled(let enabled):
@@ -76,7 +76,7 @@ extension Tasks {
                 break
             }
         }
-        
+
     }
-    
+
 }

--- a/Sources/SwiftLocation/Async Tasks/RegionMonitoring.swift
+++ b/Sources/SwiftLocation/Async Tasks/RegionMonitoring.swift
@@ -27,29 +27,29 @@ import Foundation
 import CoreLocation
 
 extension Tasks {
-    
+
     public final class RegionMonitoring: AnyTask {
-        
+
         // MARK: - Support Structures
 
         /// The event produced by the stream.
         public typealias Stream = AsyncStream<StreamEvent>
-        
+
         /// The event produced by the stream.
         public enum StreamEvent: CustomStringConvertible, Equatable {
-        
+
             /// User entered the specified region.
             case didEnterTo(region: CLRegion)
-            
+
             /// User exited from the specified region.
             case didExitTo(region: CLRegion)
-            
+
             /// A new region is being monitored.
             case didStartMonitoringFor(region: CLRegion)
-            
+
             /// Specified  region monitoring error occurred.
             case monitoringDidFailFor(region: CLRegion?, error: Error)
-            
+
             public var description: String {
                 switch self {
                 case .didEnterTo:
@@ -62,7 +62,7 @@ extension Tasks {
                     return "monitoringDidFail: \(error.localizedDescription)"
                 }
             }
-            
+
             public static func == (lhs: Tasks.RegionMonitoring.StreamEvent, rhs: Tasks.RegionMonitoring.StreamEvent) -> Bool {
                 switch (lhs, rhs) {
                 case (let .didEnterTo(r1), let .didEnterTo(r2)):
@@ -77,47 +77,47 @@ extension Tasks {
                     return false
                 }
             }
-            
+
         }
-        
+
         // MARK: - Public Properties
-        
+
         public let uuid = UUID()
         public var stream: Stream.Continuation?
         public var cancellable: CancellableTask?
-        
+
         private weak var instance: Location?
         private(set) var region: CLRegion
-        
+
         // MARK: - Initialization
 
         init(instance: Location, region: CLRegion) {
             self.instance = instance
             self.region = region
         }
-        
+
         // MARK: - Functions
 
         public func receivedLocationManagerEvent(_ event: LocationManagerBridgeEvent) {
             switch event {
             case let .didStartMonitoringFor(region):
                 stream?.yield(.didStartMonitoringFor(region: region))
-                
+
             case let .didEnterRegion(region):
                 stream?.yield(.didEnterTo(region: region))
-                
+
             case let .didExitRegion(region):
                 stream?.yield(.didExitTo(region: region))
-                
+
             case let .monitoringDidFailFor(region, error):
                 stream?.yield(.monitoringDidFailFor(region: region, error: error))
-                
+
             default:
                 break
-                
+
             }
         }
-        
+
     }
-    
+
 }

--- a/Sources/SwiftLocation/Async Tasks/SignificantLocationMonitoring.swift
+++ b/Sources/SwiftLocation/Async Tasks/SignificantLocationMonitoring.swift
@@ -27,9 +27,9 @@ import Foundation
 import CoreLocation
 
 extension Tasks {
-    
+
     public final class SignificantLocationMonitoring: AnyTask {
-        
+
         // MARK: - Support Structures
 
         /// The event produced by the stream.
@@ -37,19 +37,19 @@ extension Tasks {
 
         /// The event produced by the stream.
         public enum StreamEvent: CustomStringConvertible, Equatable {
-            
+
             /// Location changes stream paused.
             case didPaused
-            
+
             /// Location changes stream resumed.
             case didResume
-            
+
             /// New locations received.
             case didUpdateLocations(_ locations: [CLLocation])
-            
+
             /// An error has occurred.
             case didFailWithError(_ error: Error)
-            
+
             public var description: String {
                 switch self {
                 case let .didFailWithError(error):
@@ -65,32 +65,32 @@ extension Tasks {
 
                 }
             }
-            
+
             public static func == (lhs: Tasks.SignificantLocationMonitoring.StreamEvent, rhs: Tasks.SignificantLocationMonitoring.StreamEvent) -> Bool {
                 switch (lhs, rhs) {
                 case (let .didFailWithError(e1), let .didFailWithError(e2)):
                     return e1.localizedDescription == e2.localizedDescription
-                    
+
                 case (let .didUpdateLocations(l1), let .didUpdateLocations(l2)):
                     return l1 == l2
-                    
+
                 case (.didPaused, .didPaused):
                     return true
-                    
+
                 case (.didResume, .didResume):
                     return true
-                    
+
                 default:
                     return false
-                    
+
                 }
             }
         }
-        
+
         public let uuid = UUID()
         public var stream: Stream.Continuation?
         public var cancellable: CancellableTask?
-        
+
         public func receivedLocationManagerEvent(_ event: LocationManagerBridgeEvent) {
             switch event {
             case let .receiveNewLocations(locations):
@@ -105,7 +105,7 @@ extension Tasks {
                 break
             }
         }
-        
+
     }
-    
+
 }

--- a/Sources/SwiftLocation/Async Tasks/SingleUpdateLocation.swift
+++ b/Sources/SwiftLocation/Async Tasks/SingleUpdateLocation.swift
@@ -56,6 +56,7 @@ extension Tasks {
         
         // MARK: - Functions
 
+        @MainActor
         func run() async throws -> ContinuousUpdateLocation.StreamEvent {
             try await withCheckedThrowingContinuation { continuation in
                 guard let instance = self.instance else { return }

--- a/Sources/SwiftLocation/Async Tasks/SingleUpdateLocation.swift
+++ b/Sources/SwiftLocation/Async Tasks/SingleUpdateLocation.swift
@@ -58,11 +58,27 @@ extension Tasks {
 
         @MainActor
         func run() async throws -> ContinuousUpdateLocation.StreamEvent {
-            try await withCheckedThrowingContinuation { continuation in
+            return try await withCheckedThrowingContinuation { continuation in
                 guard let instance = self.instance else { return }
 
                 self.continuation = continuation
                 instance.asyncBridge.add(task: self)
+                let horizontalAccuracy = accuracyFilters?.first(where: { filter in
+                    switch filter {
+                        
+                    case .horizontal(_):
+                        return true
+                    default:
+                        return false
+                    }
+                })
+                if let horizontalAccuracy {
+                        if case .horizontal(let cLLocationAccuracy) = horizontalAccuracy {
+                            instance.locationManager.desiredAccuracy = cLLocationAccuracy
+                        }
+                        
+                    }
+                
                 instance.locationManager.requestLocation()
             }
         }

--- a/Sources/SwiftLocation/Async Tasks/SingleUpdateLocation.swift
+++ b/Sources/SwiftLocation/Async Tasks/SingleUpdateLocation.swift
@@ -87,6 +87,7 @@ extension Tasks {
         }
         
         public func didCancelled() {
+            continuation?.resume(throwing: LocationErrors.cancelled)
             continuation = nil
         }
         

--- a/Sources/SwiftLocation/Async Tasks/VisitsMonitoring.swift
+++ b/Sources/SwiftLocation/Async Tasks/VisitsMonitoring.swift
@@ -28,11 +28,11 @@ import CoreLocation
 
 #if !os(watchOS) && !os(tvOS)
 extension Tasks {
-    
+
     public final class VisitsMonitoring: AnyTask {
-        
+
         // MARK: - Support Structures
-        
+
         /// The event produced by the stream.
         public typealias Stream = AsyncStream<StreamEvent>
 
@@ -41,10 +41,10 @@ extension Tasks {
 
             /// A new visit-related event was received.
             case didVisit(_ visit: CLVisit)
-            
+
             /// Receive an error.
             case didFailWithError(_ error: Error)
-            
+
             public var description: String {
                 switch self {
                 case .didVisit:
@@ -53,7 +53,7 @@ extension Tasks {
                     return "didFailWithError: \(error.localizedDescription)"
                 }
             }
-            
+
             public static func == (lhs: Tasks.VisitsMonitoring.StreamEvent, rhs: Tasks.VisitsMonitoring.StreamEvent) -> Bool {
                 switch (lhs, rhs) {
                 case (let .didVisit(v1), let .didVisit(v2)):
@@ -65,13 +65,13 @@ extension Tasks {
                 }
             }
         }
-        
+
         // MARK: - Public Properties
 
         public let uuid = UUID()
         public var stream: Stream.Continuation?
         public var cancellable: CancellableTask?
-        
+
         // MARK: - Functions
 
         public func receivedLocationManagerEvent(_ event: LocationManagerBridgeEvent) {
@@ -85,6 +85,6 @@ extension Tasks {
             }
         }
     }
-    
+
 }
 #endif

--- a/Sources/SwiftLocation/Location Managers/LocationAsyncBridge.swift
+++ b/Sources/SwiftLocation/Location Managers/LocationAsyncBridge.swift
@@ -28,6 +28,7 @@ import CoreLocation
 
 /// This bridge is used to link the object which manage the underlying events
 /// from `CLLocationManagerDelegate`.
+@MainActor
 final class LocationAsyncBridge: CancellableTask {
     
     // MARK: - Private Properties
@@ -96,7 +97,10 @@ final class LocationAsyncBridge: CancellableTask {
         
         // store cached location
         if case .receiveNewLocations(let locations) = event {
-            location?.lastLocation = locations.last
+            Task { @MainActor in
+                location?.lastLocation = locations.last
+            }
+            
         }
     }
     

--- a/Sources/SwiftLocation/Location Managers/LocationAsyncBridge.swift
+++ b/Sources/SwiftLocation/Location Managers/LocationAsyncBridge.swift
@@ -30,14 +30,14 @@ import CoreLocation
 /// from `CLLocationManagerDelegate`.
 @MainActor
 final class LocationAsyncBridge: CancellableTask {
-    
+
     // MARK: - Private Properties
-    
+
     private var tasks = [AnyTask]()
     weak var location: Location?
 
     // MARK: - Internal function
-    
+
     /// Add a new task to the queued operations to bridge.
     ///
     /// - Parameter task: task to add.
@@ -46,14 +46,14 @@ final class LocationAsyncBridge: CancellableTask {
         tasks.append(task)
         task.willStart()
     }
-    
+
     /// Cancel the execution of a task.
     ///
     /// - Parameter task: task to cancel.
     func cancel(task: AnyTask) {
         cancel(taskUUID: task.uuid)
     }
-    
+
     /// Cancel the execution of a task with a given unique identifier.
     ///
     /// - Parameter uuid: unique identifier of the task to remove
@@ -67,7 +67,7 @@ final class LocationAsyncBridge: CancellableTask {
             }
         }
     }
-    
+
     /// Cancel the task of the given class and optional validated condition.
     ///
     /// - Parameters:
@@ -79,14 +79,14 @@ final class LocationAsyncBridge: CancellableTask {
             let isCorrectType = ($0.taskType == typeToRemove)
             let isConditionValid = (condition == nil ? true : condition!($0))
             let shouldRemove = (isCorrectType && isConditionValid)
-            
+
             if shouldRemove {
                 $0.didCancelled()
             }
             return shouldRemove
         })
     }
-    
+
     /// Dispatch the event to the tasks.
     ///
     /// - Parameter event: event to dispatch.
@@ -94,14 +94,14 @@ final class LocationAsyncBridge: CancellableTask {
         for task in tasks {
             task.receivedLocationManagerEvent(event)
         }
-        
+
         // store cached location
         if case .receiveNewLocations(let locations) = event {
             Task { @MainActor in
                 location?.lastLocation = locations.last
             }
-            
+
         }
     }
-    
+
 }

--- a/Sources/SwiftLocation/Location Managers/LocationManagerBridgeEvent.swift
+++ b/Sources/SwiftLocation/Location Managers/LocationManagerBridgeEvent.swift
@@ -28,27 +28,27 @@ import CoreLocation
 
 /// This is the list of events who can be received by any task.
 public enum LocationManagerBridgeEvent {
-    
+
     // MARK: - Authorization
-    
+
     case didChangeLocationEnabled(_ enabled: Bool)
     case didChangeAuthorization(_ status: CLAuthorizationStatus)
     case didChangeAccuracyAuthorization(_ authorization: CLAccuracyAuthorization)
 
     // MARK: - Location Monitoring
-    
+
     case locationUpdatesPaused
     case locationUpdatesResumed
     case receiveNewLocations(locations: [CLLocation])
-    
+
     // MARK: - Region Monitoring
-    
+
     case didEnterRegion(_ region: CLRegion)
     case didExitRegion(_ region: CLRegion)
     case didStartMonitoringFor(_ region: CLRegion)
 
     // MARK: - Failures
-    
+
     case didFailWithError(_ error: Error)
     case monitoringDidFailFor(region: CLRegion?, error: Error)
 
@@ -57,15 +57,15 @@ public enum LocationManagerBridgeEvent {
     #if !os(watchOS) && !os(tvOS)
     case didVisit(visit: CLVisit)
     #endif
-    
+
     // MARK: - Headings
-    
+
     #if os(iOS)
     case didUpdateHeading(_ heading: CLHeading)
     #endif
-    
+
     // MARK: - Beacons
-    
+
     #if !os(watchOS) && !os(tvOS)
     case didRange(beacons: [CLBeacon], constraint: CLBeaconIdentityConstraint)
     case didFailRanginFor(constraint: CLBeaconIdentityConstraint, error: Error)

--- a/Sources/SwiftLocation/Location Managers/LocationManagerProtocol.swift
+++ b/Sources/SwiftLocation/Location Managers/LocationManagerProtocol.swift
@@ -29,42 +29,42 @@ import CoreLocation
 /// The `CLLocationManager` implementation used to provide a mocked version
 /// of the system location manager used to write tests.
 public protocol LocationManagerProtocol {
-    
+
     // MARK: - Delegate
-    
+
     var delegate: CLLocationManagerDelegate? { get set }
-    
+
     // MARK: - Authorization
-    
+
     var authorizationStatus: CLAuthorizationStatus { get }
     var accuracyAuthorization: CLAccuracyAuthorization { get }
-    
+
     #if !os(tvOS)
     var activityType: CLActivityType { get set }
     #endif
-    
+
     var distanceFilter: CLLocationDistance { get set }
     var desiredAccuracy: CLLocationAccuracy { get set }
-    
+
     #if !os(tvOS)
     var allowsBackgroundLocationUpdates: Bool { get set }
     #endif
-    
+
     func locationServicesEnabled() -> Bool
-    
+
     // MARK: - Location Permissions
-    
+
     func validatePlistConfigurationOrThrow(permission: LocationPermission) throws
     func validatePlistConfigurationForTemporaryAccuracy(purposeKey: String) throws
     func requestWhenInUseAuthorization()
-    
+
     #if !os(tvOS)
     func requestAlwaysAuthorization()
     #endif
     func requestTemporaryFullAccuracyAuthorization(withPurposeKey purposeKey: String, completion: ((Error?) -> Void)?)
 
     // MARK: - Getting Locations
-    
+
     #if !os(tvOS)
     func startUpdatingLocation()
     func stopUpdatingLocation()
@@ -73,13 +73,13 @@ public protocol LocationManagerProtocol {
 
     #if !os(watchOS) && !os(tvOS)
     // MARK: - Monitoring Regions
-    
+
     func startMonitoring(for region: CLRegion)
     func stopMonitoring(for region: CLRegion)
     #endif
-    
+
     // MARK: - Monitoring Visits
-    
+
     #if !os(watchOS) && !os(tvOS)
     func startMonitoringVisits()
     func stopMonitoringVisits()
@@ -87,20 +87,20 @@ public protocol LocationManagerProtocol {
 
     #if !os(watchOS) && !os(tvOS)
     // MARK: - Monitoring Significant Location Changes
-    
+
     func startMonitoringSignificantLocationChanges()
     func stopMonitoringSignificantLocationChanges()
     #endif
-    
+
     #if os(iOS)
     // MARK: - Getting Heading
 
     func startUpdatingHeading()
     func stopUpdatingHeading()
     #endif
-    
+
     // MARK: - Beacon Ranging
-    
+
     #if !os(watchOS) && !os(tvOS)
     func startRangingBeacons(satisfying constraint: CLBeaconIdentityConstraint)
     func stopRangingBeacons(satisfying constraint: CLBeaconIdentityConstraint)

--- a/Sources/SwiftLocation/Location Managers/LocationManagerProtocol.swift
+++ b/Sources/SwiftLocation/Location Managers/LocationManagerProtocol.swift
@@ -50,7 +50,8 @@ public protocol LocationManagerProtocol {
     var allowsBackgroundLocationUpdates: Bool { get set }
     #endif
 
-    func locationServicesEnabled() -> Bool
+    @concurrent
+    func locationServicesEnabled() async -> Bool
 
     // MARK: - Location Permissions
 

--- a/Sources/SwiftLocation/Location.swift
+++ b/Sources/SwiftLocation/Location.swift
@@ -43,14 +43,14 @@ public final class Location {
     /// and dispatch them to the `asyncBridge` through the final output function.
     private(set) var locationDelegate: LocationDelegate
 
-    /// Cache used to store some bits of the data retrived by the underlying core location service.
+    /// Cache used to store some bits of the data retrieved by the underlying core location service.
     private let cache = UserDefaults(suiteName: "com.swiftlocation.cache")
     private let locationCacheKey = "lastLocation"
 
     // MARK: - Public Properties
 
     /// The last received location from underlying Location Manager service.
-    /// This is persistent between sesssions and store the latest result with no
+    /// This is persistent between sessions and store the latest result with no
     /// filters or logic behind.
     public internal(set) var lastLocation: CLLocation? {
         get {

--- a/Sources/SwiftLocation/Location.swift
+++ b/Sources/SwiftLocation/Location.swift
@@ -28,6 +28,7 @@ import CoreLocation
 
 /// Instantiate this class to query and setup the Location Services and all the function
 /// of the library itself.
+@MainActor
 public final class Location {
     
     // MARK: - Private Properties
@@ -67,7 +68,7 @@ public final class Location {
     public var locationServicesEnabled: Bool {
         get async {
             await Task.detached {
-                self.locationManager.locationServicesEnabled()
+                await self.locationManager.locationServicesEnabled()
             }.value
         }
     }
@@ -158,13 +159,17 @@ public final class Location {
     
     /// Initiate a new async stream to monitor the status of the location services.
     /// - Returns: observable async stream.
+    @MainActor
     public func startMonitoringLocationServices() async -> Tasks.LocationServicesEnabled.Stream {
         let task = Tasks.LocationServicesEnabled()
         return Tasks.LocationServicesEnabled.Stream { stream in
             task.stream = stream
             asyncBridge.add(task: task)
             stream.onTermination = { @Sendable _ in
-                self.stopMonitoringLocationServices()
+                Task { @MainActor in
+                    self.stopMonitoringLocationServices()
+                }
+                
             }
         }
     }
@@ -185,7 +190,10 @@ public final class Location {
             task.stream = stream
             asyncBridge.add(task: task)
             stream.onTermination = { @Sendable _ in
-                self.stopMonitoringAuthorization()
+                Task { @MainActor in
+                    self.stopMonitoringAuthorization()
+                }
+                
             }
         }
     }
@@ -206,7 +214,10 @@ public final class Location {
             task.stream = stream
             asyncBridge.add(task: task)
             stream.onTermination = { @Sendable _ in
-                self.stopMonitoringAccuracyAuthorization()
+                Task { @MainActor in
+                    self.stopMonitoringAccuracyAuthorization()
+                }
+                
             }
         }
     }
@@ -272,7 +283,10 @@ public final class Location {
             
             locationManager.startUpdatingLocation()
             stream.onTermination = { @Sendable _ in
-                self.asyncBridge.cancel(task: task)
+                Task { @MainActor in
+                    self.asyncBridge.cancel(task: task)
+                }
+                
             }
         }
     }
@@ -301,7 +315,10 @@ public final class Location {
         return try await withTaskCancellationHandler {
             try await task.run()
         } onCancel: {
-            asyncBridge.cancel(task: task)
+            Task { @MainActor in
+                asyncBridge.cancel(task: task)
+            }
+            
         }
     }
     
@@ -319,7 +336,10 @@ public final class Location {
             asyncBridge.add(task: task)
             locationManager.startMonitoring(for: region)
             stream.onTermination = { @Sendable _ in
-                self.asyncBridge.cancel(task: task)
+                Task { @MainActor in
+                    self.asyncBridge.cancel(task: task)
+                }
+                
             }
         }
     }
@@ -347,7 +367,10 @@ public final class Location {
             asyncBridge.add(task: task)
             locationManager.startMonitoringVisits()
             stream.onTermination = { @Sendable _ in
-                self.stopMonitoringVisits()
+                Task { @MainActor in
+                    self.stopMonitoringVisits()
+                }
+                
             }
         }
     }
@@ -372,7 +395,10 @@ public final class Location {
             asyncBridge.add(task: task)
             locationManager.startMonitoringSignificantLocationChanges()
             stream.onTermination = { @Sendable _ in
-                self.stopMonitoringSignificantLocationChanges()
+                Task { @MainActor in
+                    self.stopMonitoringSignificantLocationChanges()
+                }
+                
             }
         }
     }
@@ -397,7 +423,10 @@ public final class Location {
             asyncBridge.add(task: task)
             locationManager.startUpdatingHeading()
             stream.onTermination = { @Sendable _ in
-                self.stopUpdatingHeading()
+                Task { @MainActor in
+                    self.stopUpdatingHeading()
+                }
+                
             }
         }
     }
@@ -423,7 +452,10 @@ public final class Location {
             asyncBridge.add(task: task)
             locationManager.startRangingBeacons(satisfying: satisfying)
             stream.onTermination = { @Sendable _ in
-                self.stopRangingBeacons(satisfying: satisfying)
+                Task { @MainActor in
+                    self.stopRangingBeacons(satisfying: satisfying)
+                }
+                
             }
         }
     }
@@ -450,7 +482,10 @@ public final class Location {
         return try await withTaskCancellationHandler {
             try await task.requestTemporaryPermission(purposeKey: purposeKey)
         } onCancel: {
-            asyncBridge.cancel(task: task)
+            Task { @MainActor in
+                asyncBridge.cancel(task: task)
+            }
+            
         }
     }
     
@@ -462,7 +497,10 @@ public final class Location {
         return try await withTaskCancellationHandler {
             try await task.requestWhenInUsePermission()
         } onCancel: {
-            asyncBridge.cancel(task: task)
+            Task { @MainActor in
+                asyncBridge.cancel(task: task)
+            }
+            
         }
     }
     
@@ -475,7 +513,10 @@ public final class Location {
         return try await withTaskCancellationHandler {
             try await task.requestAlwaysPermission()
         } onCancel: {
-            asyncBridge.cancel(task: task)
+            Task { @MainActor in
+                asyncBridge.cancel(task: task)
+            }
+            
         }
     }
     #endif

--- a/Sources/SwiftLocation/Location.swift
+++ b/Sources/SwiftLocation/Location.swift
@@ -34,7 +34,7 @@ public final class Location {
     // MARK: - Private Properties
 
     /// Underlying location manager implementation.
-    private(set) var locationManager: LocationManagerProtocol
+    public var locationManager: LocationManagerProtocol
 
     /// Bridge for async/await communication via tasks.
     private(set) var asyncBridge = LocationAsyncBridge()
@@ -313,7 +313,7 @@ public final class Location {
         locationManager.desiredAccuracy = AccuracyFilters.highestAccuracyLevel(currentLevel: locationManager.desiredAccuracy, filters: filters)
         let task = Tasks.SingleUpdateLocation(instance: self, accuracy: filters, timeout: timeout)
         return try await withTaskCancellationHandler {
-            try await task.run()
+            return try await task.run()
         } onCancel: {
             Task { @MainActor in
                 asyncBridge.cancel(task: task)

--- a/Sources/SwiftLocation/Support/Extensions.swift
+++ b/Sources/SwiftLocation/Support/Extensions.swift
@@ -139,7 +139,7 @@ extension UserDefaults {
     }
 
     func location(forKey key: String) -> CLLocation? {
-        guard let locationData = UserDefaults.standard.data(forKey: key) else {
+        guard let locationData = self.data(forKey: key) else {
             return nil
         }
 

--- a/Sources/SwiftLocation/Support/Extensions.swift
+++ b/Sources/SwiftLocation/Support/Extensions.swift
@@ -29,11 +29,11 @@ import CoreLocation
 // MARK: - CoreLocation Extensions
 
 extension CLLocationManager: LocationManagerProtocol {
-    
+
     public func locationServicesEnabled() -> Bool {
         CLLocationManager.locationServicesEnabled()
     }
- 
+
     /// Evaluate the `Info.plist` file data and throw exceptions in case of misconfiguration.
     ///
     /// - Parameter permission: permission you would to obtain.
@@ -51,17 +51,17 @@ extension CLLocationManager: LocationManagerProtocol {
             }
         }
     }
-    
+
     public func validatePlistConfigurationForTemporaryAccuracy(purposeKey: String) throws {
         guard Bundle.hasTemporaryPermission(purposeKey: purposeKey) else {
             throw LocationErrors.plistNotConfigured
         }
     }
-    
+
 }
 
 extension CLAccuracyAuthorization: CustomStringConvertible {
-    
+
     public var description: String {
         switch self {
         case .fullAccuracy:
@@ -72,11 +72,11 @@ extension CLAccuracyAuthorization: CustomStringConvertible {
             return "Unknown (\(rawValue))"
         }
     }
-    
+
 }
 
 extension CLAuthorizationStatus: CustomStringConvertible {
-    
+
     public var description: String {
         switch self {
         case .notDetermined:        return "notDetermined"
@@ -87,7 +87,7 @@ extension CLAuthorizationStatus: CustomStringConvertible {
         @unknown default:           return "unknown"
         }
     }
-    
+
     var canMonitorLocation: Bool {
         switch self {
         case .authorizedAlways, .authorizedWhenInUse:
@@ -96,17 +96,17 @@ extension CLAuthorizationStatus: CustomStringConvertible {
             return false
         }
     }
-    
+
 }
 
 // MARK: - Foundation Extensions
 
 extension Bundle {
-    
+
     private static let alwaysAndWhenInUse = "NSLocationAlwaysAndWhenInUseUsageDescription"
     private static let whenInUse = "NSLocationWhenInUseUsageDescription"
     private static let temporary = "NSLocationTemporaryUsageDescriptionDictionary"
-    
+
     static func hasTemporaryPermission(purposeKey: String) -> Bool {
         guard let node = Bundle.main.object(forInfoDictionaryKey: temporary) as? NSDictionary,
               let value = node.object(forKey: purposeKey) as? String,
@@ -115,29 +115,29 @@ extension Bundle {
         }
         return true
     }
-    
+
     static func hasWhenInUsePermission() -> Bool {
         !(Bundle.main.object(forInfoDictionaryKey: whenInUse) as? String ?? "").isEmpty
     }
-    
+
     static func hasAlwaysAndWhenInUsePermission() -> Bool {
         !(Bundle.main.object(forInfoDictionaryKey: alwaysAndWhenInUse) as? String ?? "").isEmpty
     }
-    
+
 }
 
 extension UserDefaults {
-        
-    func set(location:CLLocation?, forKey key: String) {
+
+    func set(location: CLLocation?, forKey key: String) {
         guard let location else {
             removeObject(forKey: key)
             return
         }
-        
+
         let locationData = try? NSKeyedArchiver.archivedData(withRootObject: location, requiringSecureCoding: false)
         set(locationData, forKey: key)
     }
-    
+
     func location(forKey key: String) -> CLLocation? {
         guard let locationData = UserDefaults.standard.data(forKey: key) else {
             return nil
@@ -149,6 +149,5 @@ extension UserDefaults {
             return nil
         }
     }
-    
-}
 
+}

--- a/Sources/SwiftLocation/Support/Extensions.swift
+++ b/Sources/SwiftLocation/Support/Extensions.swift
@@ -60,7 +60,7 @@ extension CLLocationManager: LocationManagerProtocol {
 
 }
 
-extension CLAccuracyAuthorization: CustomStringConvertible {
+extension CLAccuracyAuthorization: @retroactive CustomStringConvertible {
 
     public var description: String {
         switch self {
@@ -75,7 +75,7 @@ extension CLAccuracyAuthorization: CustomStringConvertible {
 
 }
 
-extension CLAuthorizationStatus: CustomStringConvertible {
+extension CLAuthorizationStatus: @retroactive CustomStringConvertible {
 
     public var description: String {
         switch self {

--- a/Sources/SwiftLocation/Support/Extensions.swift
+++ b/Sources/SwiftLocation/Support/Extensions.swift
@@ -30,7 +30,8 @@ import CoreLocation
 
 extension CLLocationManager: LocationManagerProtocol {
 
-    public func locationServicesEnabled() -> Bool {
+    @concurrent
+    public func locationServicesEnabled() async -> Bool {
         CLLocationManager.locationServicesEnabled()
     }
 

--- a/Sources/SwiftLocation/Support/LocationDelegate.swift
+++ b/Sources/SwiftLocation/Support/LocationDelegate.swift
@@ -30,116 +30,114 @@ import CoreLocation
 /// and dispatch to the bridged tasks.
 @MainActor
 final class LocationDelegate: NSObject, @preconcurrency CLLocationManagerDelegate {
-    
+
     private weak var asyncBridge: LocationAsyncBridge?
-    
+
     private var locationManager: LocationManagerProtocol {
         asyncBridge!.location!.locationManager
     }
-    
+
     init(asyncBridge: LocationAsyncBridge) {
         self.asyncBridge = asyncBridge
         super.init()
     }
-    
+
     func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
-        
+
             asyncBridge?.dispatchEvent(.didChangeAuthorization(locationManager.authorizationStatus))
             asyncBridge?.dispatchEvent(.didChangeAccuracyAuthorization(locationManager.accuracyAuthorization))
             asyncBridge?.dispatchEvent(.didChangeLocationEnabled(locationManager.locationServicesEnabled()))
-        
+
     }
-    
+
     // MARK: - Location Updates
-    
+
      func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        
+
         asyncBridge?.dispatchEvent(.receiveNewLocations(locations: locations))
-        
+
     }
 
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
 
         asyncBridge?.dispatchEvent(.didFailWithError(error))
-        
+
     }
-    
+
     // MARK: - Heading Updates
-    
+
     #if os(iOS)
     func locationManager(_ manager: CLLocationManager, didUpdateHeading newHeading: CLHeading) {
 
         asyncBridge?.dispatchEvent(.didUpdateHeading(newHeading))
-        
+
     }
     #endif
-    
+
     #if os(iOS)
     // MARK: - Pause/Resume
 
     func locationManagerDidPauseLocationUpdates(_ manager: CLLocationManager) {
         asyncBridge?.dispatchEvent(.locationUpdatesPaused)
     }
-    
+
     func locationManagerDidResumeLocationUpdates(_ manager: CLLocationManager) {
         asyncBridge?.dispatchEvent(.locationUpdatesResumed)
-        
+
     }
     #endif
-    
+
     // MARK: - Region Monitoring
-    
+
     #if os(iOS)
     func locationManager(_ manager: CLLocationManager, monitoringDidFailFor region: CLRegion?, withError error: Error) {
         asyncBridge?.dispatchEvent(.monitoringDidFailFor(region: region, error: error))
-        
+
     }
-    
+
     func locationManager(_ manager: CLLocationManager, didEnterRegion region: CLRegion) {
-        
+
         asyncBridge?.dispatchEvent(.didEnterRegion(region))
-        
-        
+
     }
-    
+
     func locationManager(_ manager: CLLocationManager, didExitRegion region: CLRegion) {
 
         asyncBridge?.dispatchEvent(.didExitRegion(region))
-        
+
     }
-    
+
     func locationManager(_ manager: CLLocationManager, didStartMonitoringFor region: CLRegion) {
-       
+
         asyncBridge?.dispatchEvent(.didStartMonitoringFor(region))
-        
+
     }
     #endif
-    
+
     // MARK: - Visits Monitoring
-    
+
     #if os(iOS)
     func locationManager(_ manager: CLLocationManager, didVisit visit: CLVisit) {
 
         asyncBridge?.dispatchEvent(.didVisit(visit: visit))
-        
+
     }
     #endif
-    
+
     #if os(iOS)
     // MARK: - Beacons Ranging
-        
+
     func locationManager(_ manager: CLLocationManager, didRange beacons: [CLBeacon], satisfying beaconConstraint: CLBeaconIdentityConstraint) {
 
         asyncBridge?.dispatchEvent(.didRange(beacons: beacons, constraint: beaconConstraint))
-        
-        
+
     }
-        
+
     func locationManager(_ manager: CLLocationManager, didFailRangingFor beaconConstraint: CLBeaconIdentityConstraint, error: Error) {
-        
+
         asyncBridge?.dispatchEvent(.didFailRanginFor(constraint: beaconConstraint, error: error))
-        
+
     }
     #endif
-    
+
 }

--- a/Sources/SwiftLocation/Support/LocationDelegate.swift
+++ b/Sources/SwiftLocation/Support/LocationDelegate.swift
@@ -28,7 +28,8 @@ import CoreLocation
 
 /// This is the class which receive events from the `LocationManagerProtocol` implementation
 /// and dispatch to the bridged tasks.
-final class LocationDelegate: NSObject, CLLocationManagerDelegate {
+@MainActor
+final class LocationDelegate: NSObject, @preconcurrency CLLocationManagerDelegate {
     
     private weak var asyncBridge: LocationAsyncBridge?
     
@@ -42,26 +43,34 @@ final class LocationDelegate: NSObject, CLLocationManagerDelegate {
     }
     
     func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
-        asyncBridge?.dispatchEvent(.didChangeAuthorization(locationManager.authorizationStatus))
-        asyncBridge?.dispatchEvent(.didChangeAccuracyAuthorization(locationManager.accuracyAuthorization))
-        asyncBridge?.dispatchEvent(.didChangeLocationEnabled(locationManager.locationServicesEnabled()))
+        
+            asyncBridge?.dispatchEvent(.didChangeAuthorization(locationManager.authorizationStatus))
+            asyncBridge?.dispatchEvent(.didChangeAccuracyAuthorization(locationManager.accuracyAuthorization))
+            asyncBridge?.dispatchEvent(.didChangeLocationEnabled(locationManager.locationServicesEnabled()))
+        
     }
     
     // MARK: - Location Updates
     
-    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        
         asyncBridge?.dispatchEvent(.receiveNewLocations(locations: locations))
+        
     }
 
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+
         asyncBridge?.dispatchEvent(.didFailWithError(error))
+        
     }
     
     // MARK: - Heading Updates
     
     #if os(iOS)
     func locationManager(_ manager: CLLocationManager, didUpdateHeading newHeading: CLHeading) {
+
         asyncBridge?.dispatchEvent(.didUpdateHeading(newHeading))
+        
     }
     #endif
     
@@ -74,6 +83,7 @@ final class LocationDelegate: NSObject, CLLocationManagerDelegate {
     
     func locationManagerDidResumeLocationUpdates(_ manager: CLLocationManager) {
         asyncBridge?.dispatchEvent(.locationUpdatesResumed)
+        
     }
     #endif
     
@@ -82,18 +92,26 @@ final class LocationDelegate: NSObject, CLLocationManagerDelegate {
     #if os(iOS)
     func locationManager(_ manager: CLLocationManager, monitoringDidFailFor region: CLRegion?, withError error: Error) {
         asyncBridge?.dispatchEvent(.monitoringDidFailFor(region: region, error: error))
+        
     }
     
     func locationManager(_ manager: CLLocationManager, didEnterRegion region: CLRegion) {
+        
         asyncBridge?.dispatchEvent(.didEnterRegion(region))
+        
+        
     }
     
     func locationManager(_ manager: CLLocationManager, didExitRegion region: CLRegion) {
+
         asyncBridge?.dispatchEvent(.didExitRegion(region))
+        
     }
     
     func locationManager(_ manager: CLLocationManager, didStartMonitoringFor region: CLRegion) {
+       
         asyncBridge?.dispatchEvent(.didStartMonitoringFor(region))
+        
     }
     #endif
     
@@ -101,7 +119,9 @@ final class LocationDelegate: NSObject, CLLocationManagerDelegate {
     
     #if os(iOS)
     func locationManager(_ manager: CLLocationManager, didVisit visit: CLVisit) {
+
         asyncBridge?.dispatchEvent(.didVisit(visit: visit))
+        
     }
     #endif
     
@@ -109,11 +129,16 @@ final class LocationDelegate: NSObject, CLLocationManagerDelegate {
     // MARK: - Beacons Ranging
         
     func locationManager(_ manager: CLLocationManager, didRange beacons: [CLBeacon], satisfying beaconConstraint: CLBeaconIdentityConstraint) {
+
         asyncBridge?.dispatchEvent(.didRange(beacons: beacons, constraint: beaconConstraint))
+        
+        
     }
         
     func locationManager(_ manager: CLLocationManager, didFailRangingFor beaconConstraint: CLBeaconIdentityConstraint, error: Error) {
+        
         asyncBridge?.dispatchEvent(.didFailRanginFor(constraint: beaconConstraint, error: error))
+        
     }
     #endif
     

--- a/Sources/SwiftLocation/Support/LocationDelegate.swift
+++ b/Sources/SwiftLocation/Support/LocationDelegate.swift
@@ -46,7 +46,10 @@ final class LocationDelegate: NSObject, @preconcurrency CLLocationManagerDelegat
 
             asyncBridge?.dispatchEvent(.didChangeAuthorization(locationManager.authorizationStatus))
             asyncBridge?.dispatchEvent(.didChangeAccuracyAuthorization(locationManager.accuracyAuthorization))
-            asyncBridge?.dispatchEvent(.didChangeLocationEnabled(locationManager.locationServicesEnabled()))
+            Task {
+                let enabled = await locationManager.locationServicesEnabled()
+                asyncBridge?.dispatchEvent(.didChangeLocationEnabled(enabled))
+            }
 
     }
 

--- a/Sources/SwiftLocation/Support/LocationErrors.swift
+++ b/Sources/SwiftLocation/Support/LocationErrors.swift
@@ -26,7 +26,7 @@
 import Foundation
 
 /// Throwable errors
-enum LocationErrors: LocalizedError {
+public enum LocationErrors: LocalizedError {
 
     /// Info.plist authorization are not correctly defined.
     case plistNotConfigured
@@ -45,8 +45,11 @@ enum LocationErrors: LocalizedError {
 
     /// Cancelled before operation could complete.
     case cancelled
+    
+    /// LocationManager did not return any location
+    case noLocation
 
-    var errorDescription: String? {
+    public var errorDescription: String? {
         switch self {
         case .plistNotConfigured:
             return "Missing authorization into Info.plist"
@@ -60,6 +63,8 @@ enum LocationErrors: LocalizedError {
             return "Timeout"
         case .cancelled:
             return "Cancelled"
+        case .noLocation:
+            return "No location available"
         }
     }
 

--- a/Sources/SwiftLocation/Support/LocationErrors.swift
+++ b/Sources/SwiftLocation/Support/LocationErrors.swift
@@ -43,6 +43,9 @@ enum LocationErrors: LocalizedError {
     /// Operation timeout.
     case timeout
     
+    /// Cancelled before operation could complete.
+    case cancelled
+    
     var errorDescription: String? {
         switch self {
         case .plistNotConfigured:
@@ -55,6 +58,8 @@ enum LocationErrors: LocalizedError {
             return "Not Authorized"
         case .timeout:
             return "Timeout"
+        case .cancelled:
+            return "Cancelled"
         }
     }
     

--- a/Sources/SwiftLocation/Support/LocationErrors.swift
+++ b/Sources/SwiftLocation/Support/LocationErrors.swift
@@ -27,25 +27,25 @@ import Foundation
 
 /// Throwable errors
 enum LocationErrors: LocalizedError {
-    
+
     /// Info.plist authorization are not correctly defined.
     case plistNotConfigured
-    
+
     /// System location services are disabled by the user or not available.
     case locationServicesDisabled
-    
+
     /// You must require location authorization from the user before executing the operation.
     case authorizationRequired
-    
+
     /// Not authorized by the user.
     case notAuthorized
-    
+
     /// Operation timeout.
     case timeout
-    
+
     /// Cancelled before operation could complete.
     case cancelled
-    
+
     var errorDescription: String? {
         switch self {
         case .plistNotConfigured:
@@ -62,5 +62,5 @@ enum LocationErrors: LocalizedError {
             return "Cancelled"
         }
     }
-    
+
 }

--- a/Sources/SwiftLocation/Support/SupportModels.swift
+++ b/Sources/SwiftLocation/Support/SupportModels.swift
@@ -32,12 +32,12 @@ import CoreLocation
 public typealias AccuracyFilters = [AccuracyFilter]
 
 extension AccuracyFilters {
-    
+
     /// Return the highest value of the accuracy level used as filter
     /// in both horizontal and vertical direction.
     static func highestAccuracyLevel(currentLevel: CLLocationAccuracy = kCLLocationAccuracyReduced, filters: AccuracyFilters?) -> CLLocationAccuracy {
         guard let filters else { return currentLevel }
-        
+
         var value: Double = currentLevel
         for filter in filters {
             switch filter {
@@ -51,7 +51,7 @@ extension AccuracyFilters {
         }
         return value
     }
-    
+
 }
 
 /// Single Accuracy filter.
@@ -66,9 +66,9 @@ public enum AccuracyFilter {
     case course(CLLocationDirectionAccuracy)
     /// Filter using a custom function.
     case custom(_ isIncluded: ((CLLocation) -> Bool))
-                
+
     // MARK: - Internal Functions
-    
+
     /// Return a filtered array of the location which match passed filters.
     ///
     /// - Parameters:
@@ -79,7 +79,7 @@ public enum AccuracyFilter {
         guard let filters else { return locations }
         return locations.filter { AccuracyFilter.isLocation($0, validForFilters: filters) }
     }
-    
+
     /// Return if location is valid for a given set of accuracy filters.
     ///
     /// - Parameters:
@@ -91,7 +91,7 @@ public enum AccuracyFilter {
         let isValid = (firstInvalidFilter == nil)
         return isValid
     }
-    
+
     /// Return if location match `self` filter.
     ///
     /// - Parameter location: location to check.
@@ -110,7 +110,7 @@ public enum AccuracyFilter {
             return isIncluded(location)
         }
     }
-    
+
 }
 
 // MARK: - Location Accuracy
@@ -137,7 +137,7 @@ public enum LocationAccuracy {
     case bestForNavigation
     /// Custom precision, may require precise location authorization.
     case custom(Double)
-    
+
     init(level: CLLocationAccuracy) {
         switch level {
         case kCLLocationAccuracyBest:                 self = .best
@@ -149,7 +149,7 @@ public enum LocationAccuracy {
         default:                                      self = .custom(level)
         }
     }
-    
+
     internal var level: CLLocationAccuracy {
         switch self {
         case .best:                 return kCLLocationAccuracyBest

--- a/Sources/SwiftLocation/SwiftLocation.swift
+++ b/Sources/SwiftLocation/SwiftLocation.swift
@@ -26,8 +26,8 @@
 import Foundation
 
 public class SwiftLocationVersion {
-    
+
     /// Version of the SDK.
     public static let version = "6.0.1"
-        
+
 }

--- a/Tests/SwiftLocationTests/MockedLocationManager.swift
+++ b/Tests/SwiftLocationTests/MockedLocationManager.swift
@@ -28,12 +28,12 @@ import CoreLocation
 @testable import SwiftLocation
 
 public class MockedLocationManager: LocationManagerProtocol {
-    
+
     let fakeInstance = CLLocationManager()
     public weak var delegate: CLLocationManagerDelegate?
 
     public var allowsBackgroundLocationUpdates: Bool = false
-    
+
     public var isLocationServicesEnabled: Bool = true {
         didSet {
             guard isLocationServicesEnabled != oldValue else { return }
@@ -47,7 +47,7 @@ public class MockedLocationManager: LocationManagerProtocol {
 
         }
     }
-    
+
     public var accuracyAuthorization: CLAccuracyAuthorization = .reducedAccuracy {
         didSet {
             guard accuracyAuthorization != oldValue else { return }
@@ -58,15 +58,14 @@ public class MockedLocationManager: LocationManagerProtocol {
     public var desiredAccuracy: CLLocationAccuracy = 100.0
     public var activityType: CLActivityType = .other
     public var distanceFilter: CLLocationDistance = kCLDistanceFilterNone
-    
+
     public var onValidatePlistConfiguration: ((_ permission: LocationPermission) -> Error?) = { _ in
         return nil
     }
-    
+
     public var onRequestWhenInUseAuthorization: (() -> CLAuthorizationStatus) = { .notDetermined }
     public var onRequestAlwaysAuthorization: (() -> CLAuthorizationStatus) = { .notDetermined }
     public var onRequestValidationForTemporaryAccuracy: ((String) -> Error?) = { _ in return nil }
-
 
     public func updateLocations(event: Tasks.ContinuousUpdateLocation.StreamEvent) {
         switch event {
@@ -97,7 +96,7 @@ public class MockedLocationManager: LocationManagerProtocol {
         }
     }
     #endif
-    
+
     #if !os(watchOS) && !os(tvOS)
     public func updateVisits(event: Tasks.VisitsMonitoring.StreamEvent) {
         switch event {
@@ -107,109 +106,109 @@ public class MockedLocationManager: LocationManagerProtocol {
             delegate?.locationManager?(fakeInstance, didFailWithError: error)
         }
     }
-    
+
     public func updateRegionMonitoring(event: Tasks.RegionMonitoring.StreamEvent) {
         switch event {
         case let .didEnterTo(region):
             delegate?.locationManager?(fakeInstance, didEnterRegion: region)
-            
+
         case let .didExitTo(region):
             delegate?.locationManager?(fakeInstance, didExitRegion: region)
-            
+
         case let .didStartMonitoringFor(region):
             delegate?.locationManager?(fakeInstance, didStartMonitoringFor: region)
-            
+
         case let .monitoringDidFailFor(region, error):
             delegate?.locationManager?(fakeInstance, monitoringDidFailFor: region, withError: error)
-            
+
         }
     }
     #endif
-    
+
     public func validatePlistConfigurationForTemporaryAccuracy(purposeKey: String) throws {
         if let error = onRequestValidationForTemporaryAccuracy(purposeKey) {
             throw error
         }
     }
-    
+
     public func validatePlistConfigurationOrThrow(permission: LocationPermission) throws {
         if let error = onValidatePlistConfiguration(permission) {
             throw error
         }
     }
-    
+
     public func locationServicesEnabled() -> Bool {
         isLocationServicesEnabled
     }
-    
+
     public func requestAlwaysAuthorization() {
         self.authorizationStatus = onRequestAlwaysAuthorization()
     }
-    
+
     public func requestWhenInUseAuthorization() {
         self.authorizationStatus = onRequestWhenInUseAuthorization()
     }
-    
+
     public func requestTemporaryFullAccuracyAuthorization(withPurposeKey purposeKey: String, completion: ((Error?) -> Void)? = nil) {
         self.accuracyAuthorization = .fullAccuracy
         completion?(nil)
     }
-    
+
     public func startUpdatingLocation() {
-        
+
     }
-    
+
     public func stopUpdatingLocation() {
-        
+
     }
-    
+
     public func requestLocation() {
-        
+
     }
-    
+
     public func startMonitoring(for region: CLRegion) {
-        
+
     }
-    
+
     public func stopMonitoring(for region: CLRegion) {
-        
+
     }
-    
+
     public func startMonitoringVisits() {
 
     }
-    
+
     public func stopMonitoringVisits() {
-        
+
     }
-    
+
     public func startMonitoringSignificantLocationChanges() {
-        
+
     }
-    
+
     public func stopMonitoringSignificantLocationChanges() {
-        
+
     }
-    
+
     public func startUpdatingHeading() {
-        
+
     }
-    
+
     public func stopUpdatingHeading() {
-        
+
     }
-    
+
     #if !os(watchOS) && !os(tvOS)
     public func startRangingBeacons(satisfying constraint: CLBeaconIdentityConstraint) {
-        
+
     }
-    
+
     public func stopRangingBeacons(satisfying constraint: CLBeaconIdentityConstraint) {
-    
+
     }
     #endif
-    
+
     public init() {
-        
+
     }
 }

--- a/Tests/SwiftLocationTests/MockedLocationManager.swift
+++ b/Tests/SwiftLocationTests/MockedLocationManager.swift
@@ -43,7 +43,8 @@ public class MockedLocationManager: LocationManagerProtocol {
     public var authorizationStatus: CLAuthorizationStatus = .notDetermined {
         didSet {
             guard authorizationStatus != oldValue else { return }
-            delegate?.locationManagerDidChangeAuthorization?(fakeInstance)
+            self.delegate?.locationManagerDidChangeAuthorization?(fakeInstance)
+
         }
     }
     

--- a/Tests/SwiftLocationTests/MockedLocationManager.swift
+++ b/Tests/SwiftLocationTests/MockedLocationManager.swift
@@ -137,7 +137,7 @@ public class MockedLocationManager: LocationManagerProtocol {
         }
     }
 
-    public func locationServicesEnabled() -> Bool {
+    public func locationServicesEnabled() async -> Bool {
         isLocationServicesEnabled
     }
 

--- a/Tests/SwiftLocationTests/SwiftLocationTests.swift
+++ b/Tests/SwiftLocationTests/SwiftLocationTests.swift
@@ -541,12 +541,14 @@ final class SwiftLocationTests: XCTestCase {
 
     private func simulateLocationServicesChanges() -> [Bool] {
         let sequence = [false, true, false, true, true, true, false] // only real changes are detected
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2, execute: {
+        Task {
+            try await Task.sleep(for: .seconds(2))
             for value in sequence {
                 self.mockLocationManager.isLocationServicesEnabled = value
-                usleep(10)
+                print("New value: \(value)")
+                try await Task.sleep(for: .milliseconds(500))
             }
-        })
+        }
         return [false, true, false, true, false]
     }
 


### PR DESCRIPTION
I've tried using SwiftLocation in a new app I'm creating using async await. I did it according to the readme:

```swift
try await location.requestPermission(.whenInUse) // obtain the permissions
let userLocation = try await location.requestLocation() // get the location
```

I was however surprised that even though the app is supposed to await the requestPermission, in practice the app nearly immediately tried to request a location even though no button on the permission popup was tapped. Obviously no location was returned as no permission was granted.

Investigating the issue I found that CoreLocation immediately returns `.notDetermined` when the popup appears, at least it does while I was testing it on iOS 17.2. Then when the user taps a button, the correct permission is returned, but by then the `await` has already been continued with the wrong value: `.notDetermined`.

So I have added code to ignore `.notDetermined` - this now works for me, only once a user taps a button on the pop up, does the await return.