### PR TITLE
Cancelling before continuation

### DIFF
--- a/Sources/SwiftLocation/Async Tasks/SingleUpdateLocation.swift
+++ b/Sources/SwiftLocation/Async Tasks/SingleUpdateLocation.swift
@@ -87,6 +87,7 @@ extension Tasks {
         }
         
         public func didCancelled() {
+            continuation?.resume(throwing: LocationErrors.cancelled)
             continuation = nil
         }
         

--- a/Sources/SwiftLocation/Support/LocationErrors.swift
+++ b/Sources/SwiftLocation/Support/LocationErrors.swift
@@ -43,6 +43,9 @@ enum LocationErrors: LocalizedError {
     /// Operation timeout.
     case timeout
     
+    /// Cancelled before operation could complete.
+    case cancelled
+    
     var errorDescription: String? {
         switch self {
         case .plistNotConfigured:
@@ -55,6 +58,8 @@ enum LocationErrors: LocalizedError {
             return "Not Authorized"
         case .timeout:
             return "Timeout"
+        case .cancelled:
+            return "Cancelled"
         }
     }
     


### PR DESCRIPTION
If one cancels a location task before it completes, the console shows an error before continuation.resume is never called:

`SWIFT TASK CONTINUATION MISUSE: run() leaked its continuation!`

You can test this by not keeping a reference to your task, for example:

```Swift
    func refreshNearbyReports() async throws {
        
        do {
            let locationManager = Location()
            let location = try await locationManager.requestLocation()
       ...
   }

async let _ = try await refreshNearbyReports() // All tasks associated with this are immediately cancelled. 
```

This code change adds a new error case and calls .resume with it to ensure that the continuation does not leak if cancelled.