### PR TITLE
Correct Semantic Versioning in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Add it as a dependency in a Swift Package, and add it to your `Package.swift`:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/malcommac/SwiftLocation.git", from: "6.0")
+  .package(url: "https://github.com/malcommac/SwiftLocation.git", from: "6.0.0")
 ]
 ```
 # Support This Work ❤️


### PR DESCRIPTION
While integrating this package, I encountered a "Failed to parse the manifest file" error in Xcode, traced back to the "6.0" semantic versioning string `.package(..., from: "6.0")` in the README. This issue arises because Xcode cannot figure out error of the versioning ambiguity, leading to a frustrating setup experience.

This PR updates the version string to `.package(..., from: "6.0.0")`, aligning with semantic versioning standards and ensuring the Swift Package Manager can accurately parse and resolve the dependency.